### PR TITLE
Ji20/clo 19 fix derivation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Denoiser/OptixVptDenoiser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Denoiser/PyTorchDenoiser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Utils/CameraPoseLinePass.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/Utils/NormalizeNormalsPass.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Utils/Normalization.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Utils/RotationWidget.cpp
 )

--- a/Data/Shaders/BRDF/CookTorrance.glsl
+++ b/Data/Shaders/BRDF/CookTorrance.glsl
@@ -222,7 +222,6 @@ vec3 evaluateBrdfPdf(vec3 viewVector, vec3 lightVector, vec3 normalVector, vec3 
     // Diffuse Part
     // Importance Sampling pdf: 1/PI sin(theta) cos(theta)
     vec3 rhoD = baseColor;
-    rhoD *= sinThetaH * NdotH;
     
     rhoD *= vec3(1.0) - F;
     rhoD *= (1.0 - parameters.metallic);

--- a/Data/Shaders/BRDF/CookTorrance.glsl
+++ b/Data/Shaders/BRDF/CookTorrance.glsl
@@ -164,20 +164,32 @@ vec3 evaluateBrdf(vec3 viewVector, vec3 lightVector, vec3 normalVector, vec3 iso
 
     vec3 F = fresnelSchlick(VdotH, f0);
     // Specular D: GGX Distribuition
-    
     float D = D_GGX(NdotH, clamp(parameters.roughness,0.05, 1.0));
+
     // Speuclar G: G_Smith with G_1Smith-GGX
     float G = G_Smith(VdotN, LdotN, clamp(parameters.roughness,0.05, 1.0));
     // Result
-    vec3 spec = (F * G * VdotH)/(NdotH*VdotN);
-    
+    vec3 spec;
+    if (hitFlags.specularHit && !hitFlags.clearcoatHit) {
+        spec = (F * G * VdotH)/(NdotH*VdotN);
+
+    } else {
+        float sinThetaH = sqrt(1-(min(NdotH*NdotH,0.95)));
+        spec = (F * G * D * VdotH * sinThetaH)/(VdotN);
+    }
+
+
     // Diffuse Part
     vec3 rhoD = baseColor;
     
     rhoD *= vec3(1.0) - F;
     rhoD *= (1.0 - parameters.metallic);
     vec3 diff = rhoD;
-    // Whitout importance sampling: rhoD *= (1.0 / M_PI)
+    
+    if (hitFlags.specularHit) {
+        rhoD *= (1.0 / M_PI);
+    }
+    
     float sinThetaH = sqrt(1-(min(NdotH*NdotH,0.95)));
     float cosThetaH = NdotH;
 

--- a/Data/Shaders/Denoiser/NormalizeNormals.glsl
+++ b/Data/Shaders/Denoiser/NormalizeNormals.glsl
@@ -1,0 +1,50 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2022, Christoph Neuhauser
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+-- Compute
+
+#version 460
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE) in;
+
+layout(binding = 0, rgba32f) uniform readonly image2D inputImage;
+layout(binding = 1, rgba32f) uniform writeonly image2D outputImage;
+
+// Normalizes the length of all normals to 1.
+void main() {
+    ivec2 writePos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 imageSize = imageSize(inputImage);
+    if (writePos.x < imageSize.x && writePos.y < imageSize.y) {
+        vec4 normalRgba = imageLoad(inputImage, writePos);
+        float normalLength = length(normalRgba.rgb);
+        if (normalLength > 1e-5) {
+            normalRgba.rgb /= normalLength;
+        }
+        imageStore(outputImage, writePos, normalRgba);
+    }
+}

--- a/Data/Shaders/VPT/Clouds.glsl
+++ b/Data/Shaders/VPT/Clouds.glsl
@@ -206,22 +206,31 @@ void pathTraceSample(int i, bool onlyFirstEvent, out ScatterEvent firstEvent){
 #endif
 
 #ifdef WRITE_DENSITY_MAP
-    vec2 density = firstEvent.hasValue ? vec2(firstEvent.density * .001, firstEvent.density * firstEvent.density * .001 * .001) : vec2(0);
+    vec2 density = firstEvent.hasValue ? vec2(firstEvent.density * 0.001, firstEvent.density * firstEvent.density * 0.001 * 0.001) : vec2(0.0);
 #ifndef DISABLE_ACCUMULATION
-    vec2 densityOld = frame == 0 ? vec2(0) : imageLoad(densityImage, imageCoord).xy;
+    vec2 densityOld = frame == 0 ? vec2(0.0) : imageLoad(densityImage, imageCoord).xy;
     densityOld.y = densityOld.y * densityOld.y + densityOld.x * densityOld.x;
     density = mix(densityOld, density, 1.0 / float(frame + 1));
 #endif
-    imageStore(densityImage, imageCoord, vec4(density.x, sqrt(max(0.,density.y - density.x * density.x)),0,0));
+    imageStore(densityImage, imageCoord, vec4(density.x, sqrt(max(0.0, density.y - density.x * density.x)), 0.0, 0.0));
 #endif
 
 #ifdef WRITE_REPROJ_UV_MAP
-    vec2 oldReprojUV = frame == 0 ? vec2(-1,-1) : imageLoad(reprojUVImage, imageCoord).xy;
+    vec2 oldReprojUV = frame == 0 ? vec2(-1.0, -1.0) : imageLoad(reprojUVImage, imageCoord).xy;
     vec4 prevClip = (parameters.previousViewProjMatrix * vec4(firstEvent.x, 1));
     vec2 reprojUV = prevClip.xy / prevClip.w;
-    reprojUV = reprojUV * .5 + .5;
+    reprojUV = reprojUV * 0.5 + 0.5;
     reprojUV = firstEvent.hasValue ? reprojUV : oldReprojUV;
     imageStore(reprojUVImage, imageCoord, vec4(reprojUV, 0, 0));
+#endif
+
+#ifdef WRITE_ALBEDO_MAP
+    vec4 albedo = firstEvent.hasValue ? vec4(parameters.scatteringAlbedo, 1.0) : vec4(0.0);
+#ifndef DISABLE_ACCUMULATION
+    vec4 albedoOld = frame == 0.0 ? vec4(0) : imageLoad(albedoImage, imageCoord);
+    albedo = mix(albedoOld, albedo, 1.0 / float(frame + 1));
+#endif
+    imageStore(albedoImage, imageCoord, albedo);
 #endif
 
 #if defined(WRITE_DEPTH_NABLA_MAP) || defined(WRITE_DEPTH_FWIDTH_MAP)
@@ -239,10 +248,10 @@ void pathTraceSample(int i, bool onlyFirstEvent, out ScatterEvent firstEvent){
         vec3 diff = getCloudFiniteDifference(firstEvent.x);
 #endif // USE_ISOSURFACES
 #ifndef DISABLE_ACCUMULATION
-        vec3 diffOld = frame == 0 ? vec3(0) : imageLoad(normalImage, imageCoord).xyz;
-        diff = mix(diffOld, diff, 1.0 / float(frame + 1));
+        vec3 diffOld = frame == 0 ? vec3(0.0) : imageLoad(normalImage, imageCoord).xyz;
+        diff = mix(diffOld, diff, 1.0 / float(frame + 1.0));
 #endif
-        imageStore(normalImage, imageCoord, vec4(diff,1));
+        imageStore(normalImage, imageCoord, vec4(diff, 1.0));
 #endif
 
 #ifdef WRITE_FIRST_W_MAP
@@ -260,12 +269,21 @@ void pathTraceSample(int i, bool onlyFirstEvent, out ScatterEvent firstEvent){
     } else {
         //imageStore(firstX, imageCoord, vec4(0));
 
+//#ifdef WRITE_NORMAL_MAP
+//        imageStore(normalImage, imageCoord, vec4(0));
+//#endif
+
 #ifdef WRITE_NORMAL_MAP
-        imageStore(normalImage, imageCoord, vec4(0));
+#ifdef DISABLE_ACCUMULATION
+        imageStore(normalImage, imageCoord, vec4(0.0));
+#else
+        vec3 diff = frame == 0 ? vec3(0.0) : imageLoad(normalImage, imageCoord).xyz * (float(frame) / float(frame + 1.0));
+        imageStore(normalImage, imageCoord, vec4(diff, 1.0));
+#endif
 #endif
 
 #ifdef WRITE_FIRST_W_MAP
-        imageStore(firstW, imageCoord, vec4(0));
+        imageStore(firstW, imageCoord, vec4(0.0));
 #endif
     }
 

--- a/Data/Shaders/VPT/VptHeader.glsl
+++ b/Data/Shaders/VPT/VptHeader.glsl
@@ -93,6 +93,10 @@ layout (binding = 3) uniform Parameters {
     float maxAoDist;
     int numAoSamples;
 
+    // Clip plane
+    vec3 clipPlaneNormal;
+    float clipPlaneDistance;
+
     // Disney BRDF
     float subsurface;
     float metallic;

--- a/Data/Shaders/VPT/VptHeader.glsl
+++ b/Data/Shaders/VPT/VptHeader.glsl
@@ -195,8 +195,12 @@ layout (binding = 23, rg32f) uniform image2D depthNablaImage;
 layout (binding = 24, r32f) uniform image2D depthFwidthImage;
 #endif
 
+#ifdef WRITE_ALBEDO_MAP
+layout (binding = 25, rgba32f) uniform image2D albedoImage;
+#endif
+
 #ifdef WRITE_TRANSMITTANCE_VOLUME
-layout (binding = 25, r32ui) uniform uimage3D transmittanceVolumeImage;
+layout (binding = 26, r32ui) uniform uimage3D transmittanceVolumeImage;
 #endif
 
 
@@ -208,7 +212,7 @@ layout (binding = 25, r32ui) uniform uimage3D transmittanceVolumeImage;
  * This port is released under the terms of the MIT License.
  */
 /*! This function implements complex multiplication.*/
-layout(std140, binding = 26) uniform MomentUniformData {
+layout(std140, binding = 27) uniform MomentUniformData {
     vec4 wrapping_zone_parameters;
     //float overestimation;
     //float moment_bias;
@@ -216,16 +220,16 @@ layout(std140, binding = 26) uniform MomentUniformData {
 const float ABSORBANCE_MAX_VALUE = 10.0;
 
 #ifdef USE_TRANSFER_FUNCTION
-layout(binding = 27) uniform sampler1DArray transferFunctionTexture;
+layout(binding = 28) uniform sampler1DArray transferFunctionTexture;
 #endif
 
 #if defined(ISOSURFACE_TYPE_GRADIENT) || (defined(ISOSURFACE_TYPE_DENSITY) && defined(ISOSURFACE_USE_TF) && defined(USE_TRANSFER_FUNCTION))
-layout(binding = 28) uniform sampler3D gradientImage;
+layout(binding = 29) uniform sampler3D gradientImage;
 #endif
 
 #ifdef USE_OCCUPANCY_GRID
 // The occupancy grid can be used for empty space skipping with next event tracking transmittance rays.
-layout(binding = 29, r8ui) uniform readonly uimage3D occupancyGridImage;
+layout(binding = 30, r8ui) uniform readonly uimage3D occupancyGridImage;
 #endif
 
 vec2 Multiply(vec2 LHS, vec2 RHS) {

--- a/Data/Shaders/VPT/VptUtils.glsl
+++ b/Data/Shaders/VPT/VptUtils.glsl
@@ -1101,6 +1101,7 @@ bool getIsoSurfaceHit(
                         2.0 * throughput * rdfNee * weightNee / pdfLightNee *
                         calculateTransmittance(currentPoint + dirLightNee * 1e-4, dirLightNee) *
                         (sampleSkybox(dirLightNee) + sampleLight(dirLightNee));
+
                 colorNee +=
                         2.0 * throughput * weightOut * colorOut *
                         calculateTransmittance(currentPoint + dirOut * 1e-4, dirOut) *
@@ -1137,6 +1138,7 @@ bool getIsoSurfaceHit(
                         (sampleSkybox(dirLightNee) + sampleLight(dirLightNee));
             }
 #else
+
         colorNee +=
                 throughput * rdfNee / pdfLightNee *
                 calculateTransmittance(currentPoint + dirLightNee * 1e-4, dirLightNee) *
@@ -1153,6 +1155,7 @@ bool getIsoSurfaceHit(
 
     w = dirOut;
     throughput *= colorOut;
+
     return true;
 }
 

--- a/Data/Shaders/VPT/VptUtils.glsl
+++ b/Data/Shaders/VPT/VptUtils.glsl
@@ -699,6 +699,30 @@ bool rayBoxIntersect(vec3 bMin, vec3 bMax, vec3 P, vec3 D, out float tMin, out f
     if (tMax <= tMin || tMax <= 0) {
         return false;
     }
+#ifdef USE_CLIP_PLANE
+    // Compute the intersection of the ray with the clip plane
+    float denom = dot(parameters.clipPlaneNormal, D);
+    float d = dot(parameters.clipPlaneNormal, P) - parameters.clipPlaneDistance;
+
+    if (abs(denom) < 0.001) {
+        // Ray is parallel to the clip plane, return whether we are on the positive side (visible)
+        return d > 0;
+    } else {
+        float tClip = (parameters.clipPlaneDistance - dot(parameters.clipPlaneNormal, P)) / denom;
+        if (tClip <= 0) {
+            return d > 0;
+        }
+        if (d > 0) {
+            tMax = min(tClip, tMax);
+        } else {
+            tMin = max(tClip, tMin);
+        }
+    }
+
+    if (tMax <= tMin || tMax <= 0) {
+        return false;
+    }
+#endif
     return true;
 }
 

--- a/build-msvc.bat
+++ b/build-msvc.bat
@@ -94,14 +94,6 @@ if not defined VCINSTALLDIR (
     set cmake_generator=
 )
 
-IF "%VULKAN_SDK%"=="" (
-  for /D %%F in (C:\VulkanSDK\*) do (
-    set VULKAN_SDK=%%F
-    goto vulkan_finished
-  )
-)
-:vulkan_finished
-
 if not exist .\submodules\IsosurfaceCpp\src (
    echo ------------------------
    echo initializing submodules
@@ -110,27 +102,42 @@ if not exist .\submodules\IsosurfaceCpp\src (
    git submodule update || exit /b 1
 )
 
-IF "%toolchain_file%"=="" SET toolchain_file="vcpkg/scripts/buildsystems/vcpkg.cmake"
-
-set third_party_dir=%~dp0/third_party
-set cmake_args=-DCMAKE_TOOLCHAIN_FILE="third_party/%toolchain_file%" ^
-               -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet% ^
-               -DCMAKE_CXX_FLAGS="/MP" ^
-               -Dsgl_DIR="third_party/sgl/install/lib/cmake/sgl/"
-
-set cmake_args_general=-DCMAKE_TOOLCHAIN_FILE="%third_party_dir%/%toolchain_file%" ^
-               -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet%
-
 if not exist .\third_party\ mkdir .\third_party\
+set proj_dir=%~dp0
+set third_party_dir=%proj_dir%third_party
 pushd third_party
 
-if not exist .\vcpkg (
-   echo ------------------------
-   echo    fetching vcpkg
-   echo ------------------------
-   git clone --depth 1 -b fix-libarchive-rpath https://github.com/chrismile/vcpkg.git || exit /b 1
-   call vcpkg\bootstrap-vcpkg.bat -disableMetrics || exit /b 1
-   vcpkg\vcpkg install --triplet=%vcpkg_triplet% || exit /b 1
+IF "%VULKAN_SDK%"=="" (
+  for /D %%F in (C:\VulkanSDK\*) do (
+    set VULKAN_SDK=%%F
+    goto vulkan_finished
+  )
+)
+:vulkan_finished
+
+IF "%toolchain_file%"=="" (
+    SET use_vcpkg=true
+) ELSE (
+    SET use_vcpkg=false
+)
+IF "%toolchain_file%"=="" SET toolchain_file="vcpkg/scripts/buildsystems/vcpkg.cmake"
+
+set cmake_args=%cmake_args% -DCMAKE_TOOLCHAIN_FILE="third_party/%toolchain_file%" ^
+               -Dsgl_DIR="third_party/sgl/install/lib/cmake/sgl/"
+
+set cmake_args_general=%cmake_args_general% -DCMAKE_TOOLCHAIN_FILE="%third_party_dir%/%toolchain_file%"
+
+if %use_vcpkg% == true (
+    set cmake_args=%cmake_args% -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet% -DCMAKE_CXX_FLAGS="/MP"
+    set cmake_args_general=%cmake_args_general% -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet%
+    if not exist .\vcpkg (
+       echo ------------------------
+       echo    fetching vcpkg
+       echo ------------------------
+       git clone --depth 1 -b fix-libarchive-rpath https://github.com/chrismile/vcpkg.git || exit /b 1
+       call vcpkg\bootstrap-vcpkg.bat -disableMetrics || exit /b 1
+       vcpkg\vcpkg install --triplet=%vcpkg_triplet% || exit /b 1
+    )
 )
 
 if not exist .\sgl (

--- a/build-msvc.bat
+++ b/build-msvc.bat
@@ -192,6 +192,7 @@ if not exist ".\oidn-%oidn_version%.x64.windows" (
     echo ------------------------
     curl.exe -L "https://github.com/OpenImageDenoise/oidn/releases/download/v%oidn_version%/oidn-%oidn_version%.x64.windows.zip" --output oidn-%oidn_version%.x64.windows.zip
     tar -xvzf "oidn-%oidn_version%.x64.windows.zip"
+    del "oidn-%oidn_version%.x64.windows.zip"
 )
 set cmake_args=%cmake_args% -DOpenImageDenoise_DIR="third_party/oidn-%oidn_version%.x64.windows/lib/cmake/OpenImageDenoise-%oidn_version%"
 

--- a/build-msvc.bat
+++ b/build-msvc.bat
@@ -72,7 +72,7 @@ if %clean% == true (
     echo ------------------------
     rd /s /q "third_party\sgl"
     rd /s /q "third_party\vcpkg"
-    rd /s /q ".build"
+    for /d %%G in (".build*") do rd /s /q "%%~G"
     rd /s /q "Shipping"
     git submodule update --init --recursive
 )
@@ -92,6 +92,14 @@ if defined VCINSTALLDIR (
 )
 if not defined VCINSTALLDIR (
     set cmake_generator=
+)
+
+if %debug% == true (
+    set cmake_config="Debug"
+    set cmake_config_opposite="Release"
+) else (
+    set cmake_config="Release"
+    set cmake_config_opposite="Debug"
 )
 
 if not exist .\submodules\IsosurfaceCpp\src (
@@ -129,43 +137,49 @@ set cmake_args_general=%cmake_args_general% -DCMAKE_TOOLCHAIN_FILE="%third_party
 
 if %use_vcpkg% == true (
     set cmake_args=%cmake_args% -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet% -DCMAKE_CXX_FLAGS="/MP"
+    set cmake_args_sgl=-DCMAKE_CXX_FLAGS="/MP"
     set cmake_args_general=%cmake_args_general% -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet%
     if not exist .\vcpkg (
-       echo ------------------------
-       echo    fetching vcpkg
-       echo ------------------------
-       git clone --depth 1 -b fix-libarchive-rpath https://github.com/chrismile/vcpkg.git || exit /b 1
-       call vcpkg\bootstrap-vcpkg.bat -disableMetrics || exit /b 1
-       vcpkg\vcpkg install --triplet=%vcpkg_triplet% || exit /b 1
+        echo ------------------------
+        echo    fetching vcpkg
+        echo ------------------------
+        git clone --depth 1 -b fix-libarchive-rpath https://github.com/chrismile/vcpkg.git || exit /b 1
+        call vcpkg\bootstrap-vcpkg.bat -disableMetrics || exit /b 1
+        vcpkg\vcpkg install --triplet=%vcpkg_triplet% || exit /b 1
     )
 )
 
 if not exist .\sgl (
-   echo ------------------------
-   echo      fetching sgl
-   echo ------------------------
-   git clone --depth 1 https://github.com/chrismile/sgl.git   || exit /b 1
+    echo ------------------------
+    echo      fetching sgl
+    echo ------------------------
+    git clone --depth 1 https://github.com/chrismile/sgl.git   || exit /b 1
 )
 
 if not exist .\sgl\install (
-   echo ------------------------
-   echo      building sgl
-   echo ------------------------
-   mkdir sgl\.build 2> NUL
-   pushd sgl\.build
+    echo ------------------------
+    echo      building sgl
+    echo ------------------------
+    mkdir sgl\%build_dir% 2> NUL
+    pushd sgl\%build_dir%
 
-   cmake .. %cmake_generator% %cmake_args_general% ^
-            -DCMAKE_INSTALL_PREFIX="%third_party_dir%/sgl/install" -DCMAKE_CXX_FLAGS="/MP" || exit /b 1
-   if x%vcpkg_triplet:release=%==x%vcpkg_triplet% (
-      cmake --build . --config Debug   -- /m            || exit /b 1
-      cmake --build . --config Debug   --target install || exit /b 1
-   )
-   if x%vcpkg_triplet:debug=%==x%vcpkg_triplet% (
-      cmake --build . --config Release -- /m            || exit /b 1
-      cmake --build . --config Release --target install || exit /b 1
-   )
+    cmake .. %cmake_generator% %cmake_args_sgl% %cmake_args_general% ^
+            -DCMAKE_INSTALL_PREFIX="%third_party_dir%/sgl/install" || exit /b 1
+    if %use_vcpkg% == true (
+        if x%vcpkg_triplet:release=%==x%vcpkg_triplet% (
+           cmake --build . --config Debug   -- /m            || exit /b 1
+           cmake --build . --config Debug   --target install || exit /b 1
+        )
+        if x%vcpkg_triplet:debug=%==x%vcpkg_triplet% (
+           cmake --build . --config Release -- /m            || exit /b 1
+           cmake --build . --config Release --target install || exit /b 1
+        )
+    ) else (
+        cmake --build . --config %cmake_config%                  || exit /b 1
+        cmake --build . --config %cmake_config% --target install || exit /b 1
+    )
 
-   popd
+    popd
 )
 
 if %build_with_openvdb_support% == true (
@@ -208,19 +222,13 @@ set cmake_args=%cmake_args% -DOpenImageDenoise_DIR="third_party/oidn-%oidn_versi
 popd
 
 if %debug% == true (
-   echo ------------------------
-   echo   building in debug
-   echo ------------------------
-
-   set cmake_config="Debug"
-   set cmake_config_opposite="Release"
+    echo ------------------------
+    echo   building in debug
+    echo ------------------------
 ) else (
-   echo ------------------------
-   echo   building in release
-   echo ------------------------
-
-   set cmake_config="Release"
-   set cmake_config_opposite="Debug"
+    echo ------------------------
+    echo   building in release
+    echo ------------------------
 )
 
 echo ------------------------
@@ -237,25 +245,29 @@ cmake %cmake_generator% %cmake_args% -S . -B %build_dir%
 echo ------------------------
 echo       compiling
 echo ------------------------
-cmake --build %build_dir% --config %cmake_config% -- /m || exit /b 1
+if %use_vcpkg% == true (
+    cmake --build %build_dir% --config %cmake_config% -- /m || exit /b 1
+) else (
+    cmake --build %build_dir% --config %cmake_config%       || exit /b 1
+)
 
 echo ------------------------
 echo    copying new files
 echo ------------------------
 robocopy third_party\oidn-%oidn_version%.x64.windows\bin %destination_dir% *.dll >NUL
 if %debug% == true (
-   if not exist %destination_dir%\*.pdb (
-      del %destination_dir%\*.dll
-   )
-   robocopy %build_dir%\Debug\ %destination_dir% >NUL
-   robocopy third_party\sgl\.build\Debug %destination_dir% *.dll *.pdb >NUL
+    if not exist %destination_dir%\*.pdb (
+        del %destination_dir%\*.dll
+    )
+    robocopy %build_dir%\Debug\ %destination_dir% >NUL
+    robocopy third_party\sgl\%build_dir%\Debug %destination_dir% *.dll *.pdb >NUL
 ) else (
-   if exist %destination_dir%\*.pdb (
-      del %destination_dir%\*.dll
-      del %destination_dir%\*.pdb
-   )
-   robocopy %build_dir%\Release\ %destination_dir% >NUL
-   robocopy third_party\sgl\.build\Release %destination_dir% *.dll >NUL
+    if exist %destination_dir%\*.pdb (
+        del %destination_dir%\*.dll
+        del %destination_dir%\*.pdb
+    )
+    robocopy %build_dir%\Release\ %destination_dir% >NUL
+    robocopy third_party\sgl\%build_dir%\Release %destination_dir% *.dll >NUL
 )
 
 :: Build other configuration and copy sgl DLLs to the build directory.
@@ -263,9 +275,13 @@ if %devel% == true (
     echo ------------------------
     echo   setting up dev files
     echo ------------------------
-    cmake --build %build_dir% --config %cmake_config_opposite% -- /m || exit /b 1
-    robocopy third_party\sgl\.build\Debug %build_dir%\Debug\ *.dll *.pdb >NUL
-    robocopy third_party\sgl\.build\Release %build_dir%\Release\ *.dll >NUL
+    if %use_vcpkg% == true (
+        cmake --build %build_dir% --config %cmake_config_opposite% -- /m || exit /b 1
+    ) else (
+        cmake --build %build_dir% --config %cmake_config_opposite%       || exit /b 1
+    )
+    robocopy third_party\sgl\%build_dir%\Debug %build_dir%\Debug\ *.dll *.pdb >NUL
+    robocopy third_party\sgl\%build_dir%\Release %build_dir%\Release\ *.dll >NUL
     robocopy third_party\oidn-%oidn_version%.x64.windows\bin %build_dir%\Debug\ *.dll *.pdb >NUL
     robocopy third_party\oidn-%oidn_version%.x64.windows\bin %build_dir%\Release\ *.dll >NUL
     if %build_with_openvdb_support% == true (
@@ -280,7 +296,7 @@ echo All done!
 pushd %destination_dir%
 
 if %run_program% == true (
-   CloudRendering.exe
+    CloudRendering.exe
 ) else (
-   echo Build finished.
+    echo Build finished.
 )

--- a/build-msvc.bat
+++ b/build-msvc.bat
@@ -110,13 +110,15 @@ if not exist .\submodules\IsosurfaceCpp\src (
    git submodule update || exit /b 1
 )
 
+IF "%toolchain_file%"=="" SET toolchain_file="vcpkg/scripts/buildsystems/vcpkg.cmake"
+
 set third_party_dir=%~dp0/third_party
-set cmake_args=-DCMAKE_TOOLCHAIN_FILE="third_party/vcpkg/scripts/buildsystems/vcpkg.cmake" ^
+set cmake_args=-DCMAKE_TOOLCHAIN_FILE="third_party/%toolchain_file%" ^
                -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet% ^
                -DCMAKE_CXX_FLAGS="/MP" ^
                -Dsgl_DIR="third_party/sgl/install/lib/cmake/sgl/"
 
-set cmake_args_general=-DCMAKE_TOOLCHAIN_FILE="%third_party_dir%/vcpkg/scripts/buildsystems/vcpkg.cmake" ^
+set cmake_args_general=-DCMAKE_TOOLCHAIN_FILE="%third_party_dir%/%toolchain_file%" ^
                -DVCPKG_TARGET_TRIPLET=%vcpkg_triplet%
 
 if not exist .\third_party\ mkdir .\third_party\
@@ -238,7 +240,7 @@ if %debug% == true (
    if not exist %destination_dir%\*.pdb (
       del %destination_dir%\*.dll
    )
-   robocopy %build_dir%\Debug\  %destination_dir%  >NUL
+   robocopy %build_dir%\Debug\ %destination_dir% >NUL
    robocopy third_party\sgl\.build\Debug %destination_dir% *.dll *.pdb >NUL
 ) else (
    if exist %destination_dir%\*.pdb (

--- a/build.sh
+++ b/build.sh
@@ -1315,7 +1315,6 @@ elif [ $use_macos = true ] && [ $use_vcpkg = false ]; then
             codesign --force -s - "$filename" &> /dev/null
         fi
     done
-${copy_dependencies_macos_post}
 else
     mkdir -p $destination_dir/bin
 
@@ -1325,6 +1324,19 @@ else
     # Copy all dependencies of the application to the destination directory.
     ldd_output="$(ldd $build_dir/CloudRendering)"
 
+    if $use_open_image_denoise; then
+        # Copy OpenImageDenoise device libraries.
+        for oidn_lib_file in "${projectpath}/third_party/${oidn_folder_name}/lib/libOpenImageDenoise_device_"*; do
+            ldd_output="$ldd_output ${oidn_lib_file}"
+        done
+        # Copy other dependencies.
+        for oidn_lib_file in "${projectpath}/third_party/${oidn_folder_name}/lib/lib"*; do
+            oidn_lib_file_basename="$(basename ${oidn_lib_file})"
+            if [[ ${oidn_lib_file_basename} != "libOpenImageDenoise"* ]]; then
+                ldd_output="$ldd_output ${oidn_lib_file}"
+            fi
+        done
+    fi
     library_blacklist=(
         "libOpenGL" "libGLdispatch" "libGL.so" "libGLX.so"
         "libwayland" "libffi." "libX" "libxcb" "libxkbcommon"

--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,6 @@ use_download_swapchain=false
 use_custom_jsoncpp=false
 use_custom_openexr=false
 use_open_image_denoise=true
-if $use_macos || $use_msys; then
-    # OpenImageDenoise needs more testing on macOS (due to Metal buffer sharing) and MinGW (due to MSVC compat tests).
-    use_open_image_denoise=false
-fi
 
 # Check if a conda environment is already active.
 if $use_conda; then
@@ -988,18 +984,21 @@ fi
 
 if $use_open_image_denoise; then
     oidn_version="2.3.0"
-    if [ ! -d "./oidn-${oidn_version}.x86_64.linux" ]; then
+    if $use_msys; then
+        oidn_folder_name="oidn-${oidn_version}.x64.windows"
+    elif $use_macos; then
+        oidn_folder_name="oidn-${oidn_version}.${os_arch}.linux"
+    else
+        oidn_folder_name="oidn-${oidn_version}.${os_arch}.macos"
+    fi
+    if [ ! -d "./${oidn_folder_name}" ]; then
         echo "------------------------"
         echo "downloading OpenImageDenoise"
         echo "------------------------"
-        #https://github.com/OpenImageDenoise/oidn/releases/download/v2.3.0/oidn-2.3.0.x86_64.linux.tar.gz
-        #https://github.com/OpenImageDenoise/oidn/releases/download/v2.3.0/oidn-2.3.0.x64.windows.zip
-        #https://github.com/OpenImageDenoise/oidn/releases/download/v2.3.0/oidn-2.3.0.arm64.macos.tar.gz
-        #https://github.com/OpenImageDenoise/oidn/releases/download/v2.3.0/oidn-2.3.0.x86_64.macos.tar.gz
-        wget "https://github.com/OpenImageDenoise/oidn/releases/download/v${oidn_version}/oidn-${oidn_version}.x86_64.linux.tar.gz"
+        wget "https://github.com/OpenImageDenoise/oidn/releases/download/v${oidn_version}/${oidn_folder_name}.tar.gz"
         tar -xvzf "oidn-${oidn_version}.x86_64.linux.tar.gz"
     fi
-    params+=(-DOpenImageDenoise_DIR="${projectpath}/third_party/oidn-${oidn_version}.x86_64.linux/lib/cmake/OpenImageDenoise-${oidn_version}")
+    params+=(-DOpenImageDenoise_DIR="${projectpath}/third_party/${oidn_folder_name}/lib/cmake/OpenImageDenoise-${oidn_version}")
 fi
 
 popd >/dev/null # back to project root

--- a/build.sh
+++ b/build.sh
@@ -253,12 +253,12 @@ list_contains() {
 
 if $use_msys && command -v pacman &> /dev/null && [ ! -d $build_dir_debug ] && [ ! -d $build_dir_release ]; then
     if ! command -v cmake &> /dev/null || ! command -v git &> /dev/null || ! command -v rsync &> /dev/null \
-            || ! command -v curl &> /dev/null || ! command -v wget &> /dev/null \
+            || ! command -v curl &> /dev/null || ! command -v wget &> /dev/null || ! command -v unzip &> /dev/null \
             || ! command -v pkg-config &> /dev/null || ! command -v g++ &> /dev/null; then
         echo "------------------------"
         echo "installing build essentials"
         echo "------------------------"
-        pacman --noconfirm -S --needed make git rsync curl wget mingw64/mingw-w64-x86_64-cmake \
+        pacman --noconfirm -S --needed make git rsync curl wget unzip mingw64/mingw-w64-x86_64-cmake \
         mingw64/mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-gdb
     fi
 

--- a/build.sh
+++ b/build.sh
@@ -999,7 +999,11 @@ if $use_open_image_denoise; then
         echo "downloading OpenImageDenoise"
         echo "------------------------"
         wget "https://github.com/OpenImageDenoise/oidn/releases/download/v${oidn_version}/${oidn_archive_name}"
-        tar -xvzf "${oidn_archive_name}"
+        if $use_msys; then
+            unzip "${oidn_archive_name}"
+        elif $use_macos; then
+            tar -xvzf "${oidn_archive_name}"
+        fi
     fi
     params+=(-DOpenImageDenoise_DIR="${projectpath}/third_party/${oidn_folder_name}/lib/cmake/OpenImageDenoise-${oidn_version}")
 fi

--- a/build.sh
+++ b/build.sh
@@ -1206,10 +1206,24 @@ if $use_msys; then
 
     # Copy all dependencies of the application to the destination directory.
     ldd_output="$(ntldd -R $build_dir/CloudRendering.exe)"
+    if $use_open_image_denoise; then
+        # Copy OpenImageDenoise device libraries.
+        for oidn_lib_file in "${projectpath}/third_party/${oidn_folder_name}/bin/OpenImageDenoise_device_"*; do
+            ldd_output="$ldd_output ${oidn_lib_file}"
+        done
+        # Copy other dependencies.
+        for oidn_lib_file in "${projectpath}/third_party/${oidn_folder_name}/bin/"*.dll; do
+            oidn_lib_file_basename="$(basename ${oidn_lib_file})"
+            if [[ ${oidn_lib_file_basename} != "OpenImageDenoise"* ]]; then
+                ldd_output="$ldd_output ${oidn_lib_file}"
+            fi
+        done
+    fi
     for library_abs in $ldd_output
     do
-        if [[ $library == "not found"* ]] || [[ $library == "ext-ms-win"* ]] || [[ $library == "=>"* ]] \
-                || [[ $library == "(0x"* ]] || [[ $library == "C:\\WINDOWS"* ]]; then
+        if [[ $library_abs == "not found"* ]] || [[ $library_abs == "ext-ms-win"* ]] || [[ $library_abs == "=>" ]] \
+                || [[ $library_abs == "(0x"* ]] || [[ $library_abs == "C:\\WINDOWS"* ]] \
+                || [[ $library_abs == "not" ]] || [[ $library_abs == "found"* ]]; then
             continue
         fi
         library="$(cygpath "$library_abs")"

--- a/build.sh
+++ b/build.sh
@@ -1102,6 +1102,11 @@ if [ $use_pytorch = true ] && [ $install_module = true ]; then
     fi
     if $use_open_image_denoise; then
         cp $(ldd $build_dir/libvpt.so | grep OpenImage | awk 'NF == 4 {print $3}; NF == 2 {print $1}') "$install_dir/modules"
+        if [ $use_macos = false ] && [ $use_vcpkg = false ]; then
+            for oidn_file in "$install_dir/modules/libOpenImageDenoise.*"; do
+                patchelf --set-rpath '$ORIGIN' "${oidn_file}"
+            done
+        fi
     fi
     patchelf --set-rpath '$ORIGIN' "$install_dir/modules/libvpt.so"
 fi

--- a/build.sh
+++ b/build.sh
@@ -1103,7 +1103,7 @@ if [ $use_pytorch = true ] && [ $install_module = true ]; then
     if $use_open_image_denoise; then
         cp $(ldd $build_dir/libvpt.so | grep OpenImage | awk 'NF == 4 {print $3}; NF == 2 {print $1}') "$install_dir/modules"
         if [ $use_macos = false ] && [ $use_vcpkg = false ]; then
-            for oidn_file in "$install_dir/modules/libOpenImageDenoise.*"; do
+            for oidn_file in "$install_dir/modules/libOpenImageDenoise."*; do
                 patchelf --set-rpath '$ORIGIN' "${oidn_file}"
             done
         fi

--- a/build.sh
+++ b/build.sh
@@ -1106,6 +1106,19 @@ if [ $use_pytorch = true ] && [ $install_module = true ]; then
             for oidn_file in "$install_dir/modules/libOpenImageDenoise."*; do
                 patchelf --set-rpath '$ORIGIN' "${oidn_file}"
             done
+            # Copy OpenImageDenoise device libraries.
+            for oidn_lib_file in "${projectpath}/third_party/${oidn_folder_name}/lib/libOpenImageDenoise_device_"*; do
+                cp "${oidn_lib_file}" "$install_dir/modules"
+                patchelf --set-rpath '$ORIGIN' "$install_dir/modules/$(basename ${oidn_lib_file})"
+            done
+            # Copy other dependencies.
+            for oidn_lib_file in "${projectpath}/third_party/${oidn_folder_name}/lib/lib"*; do
+                oidn_lib_file_basename="$(basename ${oidn_lib_file})"
+                if [[ ${oidn_lib_file_basename} != "libOpenImageDenoise"* ]]; then
+                    cp "${oidn_lib_file}" "$install_dir/modules"
+                    patchelf --set-rpath '$ORIGIN' "$install_dir/modules/${oidn_lib_file_basename}"
+                fi
+            done
         fi
     fi
     patchelf --set-rpath '$ORIGIN' "$install_dir/modules/libvpt.so"

--- a/build.sh
+++ b/build.sh
@@ -986,17 +986,20 @@ if $use_open_image_denoise; then
     oidn_version="2.3.0"
     if $use_msys; then
         oidn_folder_name="oidn-${oidn_version}.x64.windows"
+        oidn_archive_name="${oidn_folder_name}.zip"
     elif $use_macos; then
         oidn_folder_name="oidn-${oidn_version}.${os_arch}.linux"
+        oidn_archive_name="${oidn_folder_name}.tar.gz"
     else
         oidn_folder_name="oidn-${oidn_version}.${os_arch}.macos"
+        oidn_archive_name="${oidn_folder_name}.tar.gz"
     fi
     if [ ! -d "./${oidn_folder_name}" ]; then
         echo "------------------------"
         echo "downloading OpenImageDenoise"
         echo "------------------------"
-        wget "https://github.com/OpenImageDenoise/oidn/releases/download/v${oidn_version}/${oidn_folder_name}.tar.gz"
-        tar -xvzf "oidn-${oidn_version}.x86_64.linux.tar.gz"
+        wget "https://github.com/OpenImageDenoise/oidn/releases/download/v${oidn_version}/${oidn_archive_name}"
+        tar -xvzf "${oidn_archive_name}"
     fi
     params+=(-DOpenImageDenoise_DIR="${projectpath}/third_party/${oidn_folder_name}/lib/cmake/OpenImageDenoise-${oidn_version}")
 fi

--- a/build.sh
+++ b/build.sh
@@ -989,10 +989,10 @@ if $use_open_image_denoise; then
         oidn_folder_name="oidn-${oidn_version}.x64.windows"
         oidn_archive_name="${oidn_folder_name}.zip"
     elif $use_macos; then
-        oidn_folder_name="oidn-${oidn_version}.${os_arch}.linux"
+        oidn_folder_name="oidn-${oidn_version}.${os_arch}.macos"
         oidn_archive_name="${oidn_folder_name}.tar.gz"
     else
-        oidn_folder_name="oidn-${oidn_version}.${os_arch}.macos"
+        oidn_folder_name="oidn-${oidn_version}.${os_arch}.linux"
         oidn_archive_name="${oidn_folder_name}.tar.gz"
     fi
     if [ ! -d "./${oidn_folder_name}" ]; then
@@ -1002,7 +1002,7 @@ if $use_open_image_denoise; then
         wget "https://github.com/OpenImageDenoise/oidn/releases/download/v${oidn_version}/${oidn_archive_name}"
         if $use_msys; then
             unzip "${oidn_archive_name}"
-        elif $use_macos; then
+        else
             tar -xvzf "${oidn_archive_name}"
         fi
         rm "${oidn_archive_name}"

--- a/docs/license-libraries/blosc/LICENSE-bitshuffle.txt
+++ b/docs/license-libraries/blosc/LICENSE-bitshuffle.txt
@@ -1,0 +1,21 @@
+Bitshuffle - Filter for improving compression of typed binary data.
+
+Copyright (c) 2014 Kiyoshi Masui (kiyo@physics.ubc.ca)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/docs/license-libraries/blosc/LICENSE-blosc.txt
+++ b/docs/license-libraries/blosc/LICENSE-blosc.txt
@@ -1,0 +1,31 @@
+BSD License
+
+For Blosc - A blocking, shuffling and lossless compression library
+
+Copyright (C) 2009-2018 Francesc Alted <francesc@blosc.org>
+Copyright (C) 2019-present Blosc Development team <blosc@blosc.org>
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Francesc Alted nor the names of its contributors may be used
+   to endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/license-libraries/blosc/LICENSE-fastlz.txt
+++ b/docs/license-libraries/blosc/LICENSE-fastlz.txt
@@ -1,0 +1,24 @@
+FastLZ - lightning-fast lossless compression library
+
+Copyright (C) 2007 Ariya Hidayat (ariya@kde.org)
+Copyright (C) 2006 Ariya Hidayat (ariya@kde.org)
+Copyright (C) 2005 Ariya Hidayat (ariya@kde.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/docs/license-libraries/blosc/LICENSE-lz4.txt
+++ b/docs/license-libraries/blosc/LICENSE-lz4.txt
@@ -1,0 +1,32 @@
+LZ4 - Fast LZ compression algorithm
+
+Copyright (C) 2011-2014, Yann Collet.
+BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You can contact the author at :
+- LZ4 homepage : http://fastcompression.blogspot.com/p/lz4.html
+- LZ4 source repository : http://code.google.com/p/lz4/
+

--- a/docs/license-libraries/blosc/LICENSE-snappy.txt
+++ b/docs/license-libraries/blosc/LICENSE-snappy.txt
@@ -1,0 +1,28 @@
+Copyright 2011, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/license-libraries/blosc/LICENSE-stdint.txt
+++ b/docs/license-libraries/blosc/LICENSE-stdint.txt
@@ -1,0 +1,29 @@
+ISO C9x  compliant stdint.h for Microsoft Visual Studio
+Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124
+
+ Copyright (c) 2006-2013 Alexander Chemeris
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  3. Neither the name of the product nor the names of its contributors may
+     be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/license-libraries/blosc/LICENSE-zlib.txt
+++ b/docs/license-libraries/blosc/LICENSE-zlib.txt
@@ -1,0 +1,22 @@
+Copyright notice:
+
+ (C) 1995-2013 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu

--- a/docs/license-libraries/graphics/LICENSE-openvdb.txt
+++ b/docs/license-libraries/graphics/LICENSE-openvdb.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/docs/license-libraries/openimagedenoise/LICENSE-openimagedenoise.txt
+++ b/docs/license-libraries/openimagedenoise/LICENSE-openimagedenoise.txt
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/docs/license-libraries/openimagedenoise/third-party-programs-DPCPP.txt
+++ b/docs/license-libraries/openimagedenoise/third-party-programs-DPCPP.txt
@@ -1,0 +1,110 @@
+
+The oneAPI DPC++ Compiler can be found here:
+
+  https://github.com/intel/llvm
+
+It uses various components with following licenses:
+
+  https://github.com/intel/llvm/blob/master/flang/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/compiler-rt/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/mlir/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/libclc/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/libcxxabi/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/lld/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/cross-project-tests/debuginfo-tests/dexter/LICENSE.txt
+  https://github.com/intel/llvm/blob/master/libc/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/clang-tools-extra/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/clang-tools-extra/clang-tidy/cert/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/clang-tools-extra/clang-tidy/hicpp/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/lldb/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/lldb/third_party/Python/module/ptyprocess-0.6.0/LICENSE
+  https://github.com/intel/llvm/blob/master/lldb/third_party/Python/module/six/LICENSE
+  https://github.com/intel/llvm/blob/master/lldb/third_party/Python/module/pexpect-4.6/LICENSE
+  https://github.com/intel/llvm/blob/master/polly/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/polly/lib/External/isl/LICENSE
+  https://github.com/intel/llvm/blob/master/polly/lib/External/isl/imath/LICENSE
+  https://github.com/intel/llvm/blob/master/polly/tools/GPURuntime/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/sycl/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/llvm-spirv/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/bolt/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/pstl/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/clang/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/llvm/utils/lit/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/llvm/utils/unittest/googletest/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/llvm/utils/unittest/googlemock/LICENSE.txt
+  https://github.com/intel/llvm/blob/master/llvm/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/llvm/include/llvm/Support/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/llvm/lib/Support/BLAKE3/LICENSE
+  https://github.com/intel/llvm/blob/master/llvm/test/YAMLParser/LICENSE.txt
+  https://github.com/intel/llvm/blob/master/libunwind/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/openmp/LICENSE.TXT
+  https://github.com/intel/llvm/blob/master/openmp/runtime/src/thirdparty/ittnotify/LICENSE.txt
+  https://github.com/intel/llvm/blob/master/third-party/benchmark/LICENSE
+  https://github.com/intel/llvm/blob/master/libcxx/LICENSE.TXT
+
+The following people and companies contributed to the LLVM project:
+
+  https://github.com/intel/llvm/blob/master/compiler-rt/CREDITS.TXT
+  https://github.com/intel/llvm/blob/master/libclc/CREDITS.TXT
+  https://github.com/intel/llvm/blob/master/libcxxabi/CREDITS.TXT
+  https://github.com/intel/llvm/blob/master/polly/CREDITS.txt
+  https://github.com/intel/llvm/blob/master/pstl/CREDITS.txt
+  https://github.com/intel/llvm/blob/master/llvm/CREDITS.TXT
+  https://github.com/intel/llvm/blob/master/openmp/CREDITS.txt
+  https://github.com/intel/llvm/blob/master/libcxx/CREDITS.TXT
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2020 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/docs/license-libraries/openimagedenoise/third-party-programs-oneDNN.txt
+++ b/docs/license-libraries/openimagedenoise/third-party-programs-oneDNN.txt
@@ -1,0 +1,583 @@
+oneAPI Deep Neural Network Library (oneDNN) Third Party Programs File
+
+This file contains the list of third party software ("third party programs")
+contained in the Intel software and their required notices and/or license
+terms. This third party software, even if included with the distribution of
+the Intel software, may be governed by separate license terms, including
+without limitation, third party license terms, other Intel software license
+terms, and open source software license terms. These separate license terms
+govern your use of the third party programs as set forth in in the
+"THIRD-PARTY-PROGRAMS" file.
+
+Third party programs and their corresponding required notices and/or license
+terms are listed below.
+
+--------------------------------------------------------------------------------
+1. XByak (src/cpu/xbyak/)
+Copyright (c) 2007 MITSUNARI Shigeo
+All rights reserved.
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+Neither the name of the copyright owner nor the names of its contributors may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ソースコード形式かバイナリ形式か、変更するかしないかを問わず、以下の条件を満た
+す場合に限り、再頒布および使用が許可されます。
+
+ソースコードを再頒布する場合、上記の著作権表示、本条件一覧、および下記免責条項
+を含めること。
+バイナリ形式で再頒布する場合、頒布物に付属のドキュメント等の資料に、上記の著作
+権表示、本条件一覧、および下記免責条項を含めること。
+書面による特別の許可なしに、本ソフトウェアから派生した製品の宣伝または販売促進
+に、著作権者の名前またはコントリビューターの名前を使用してはならない。
+本ソフトウェアは、著作権者およびコントリビューターによって「現状のまま」提供さ
+れており、明示黙示を問わず、商業的な使用可能性、および特定の目的に対する適合性
+に関する暗黙の保証も含め、またそれに限定されない、いかなる保証もありません。
+著作権者もコントリビューターも、事由のいかんを問わず、 損害発生の原因いかんを
+問わず、かつ責任の根拠が契約であるか厳格責任であるか（過失その他の）不法行為で
+あるかを問わず、仮にそのような損害が発生する可能性を知らされていたとしても、
+本ソフトウェアの使用によって発生した（代替品または代用サービスの調達、使用の
+喪失、データの喪失、利益の喪失、業務の中断も含め、またそれに限定されない）直接
+損害、間接損害、偶発的な損害、特別損害、懲罰的損害、または結果損害について、
+一切責任を負わないものとします。
+
+--------------------------------------------------------------------------------
+2. Googletest (tests/gtests/gtest/)
+Copyright 2005, Google Inc.
+Copyright 2006, Google Inc.
+Copyright 2007, Google Inc.
+Copyright 2008, Google Inc.
+Copyright 2015, Google Inc.
+All rights reserved.
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+3. Instrumentation and Tracing Technology API (src/common/ittnotify/)
+Copyright (c) 2011, Intel Corporation. All rights reserved.
+Copyright (c) 2005-2014 Intel Corporation. All rights reserved.
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of Intel Corporation nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+4. CMake (cmake/FindOpenCL.cmake, cmake/FindBLAS.cmake, cmake/FindACL.cmake)
+CMake - Cross Platform Makefile Generator
+Copyright 2000-2020 Kitware, Inc. and Contributors
+All rights reserved.
+
+3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of Kitware, Inc. nor the names of Contributors
+  may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+
+The following individuals and institutions are among the Contributors:
+
+* Aaron C. Meadows <cmake@shadowguarddev.com>
+* Adriaan de Groot <groot@kde.org>
+* Aleksey Avdeev <solo@altlinux.ru>
+* Alexander Neundorf <neundorf@kde.org>
+* Alexander Smorkalov <alexander.smorkalov@itseez.com>
+* Alexey Sokolov <sokolov@google.com>
+* Alex Merry <alex.merry@kde.org>
+* Alex Turbov <i.zaufi@gmail.com>
+* Andreas Pakulat <apaku@gmx.de>
+* Andreas Schneider <asn@cryptomilk.org>
+* André Rigland Brodtkorb <Andre.Brodtkorb@ifi.uio.no>
+* Axel Huebl, Helmholtz-Zentrum Dresden - Rossendorf
+* Benjamin Eikel
+* Bjoern Ricks <bjoern.ricks@gmail.com>
+* Brad Hards <bradh@kde.org>
+* Christopher Harvey
+* Christoph Grüninger <foss@grueninger.de>
+* Clement Creusot <creusot@cs.york.ac.uk>
+* Daniel Blezek <blezek@gmail.com>
+* Daniel Pfeifer <daniel@pfeifer-mail.de>
+* Enrico Scholz <enrico.scholz@informatik.tu-chemnitz.de>
+* Eran Ifrah <eran.ifrah@gmail.com>
+* Esben Mose Hansen, Ange Optimization ApS
+* Geoffrey Viola <geoffrey.viola@asirobots.com>
+* Google Inc
+* Gregor Jasny
+* Helio Chissini de Castro <helio@kde.org>
+* Ilya Lavrenov <ilya.lavrenov@itseez.com>
+* Insight Software Consortium <insightsoftwareconsortium.org>
+* Jan Woetzel
+* Julien Schueller
+* Kelly Thompson <kgt@lanl.gov>
+* Konstantin Podsvirov <konstantin@podsvirov.pro>
+* Laurent Montel <montel@kde.org>
+* Mario Bensi <mbensi@ipsquad.net>
+* Martin Gräßlin <mgraesslin@kde.org>
+* Mathieu Malaterre <mathieu.malaterre@gmail.com>
+* Matthaeus G. Chajdas
+* Matthias Kretz <kretz@kde.org>
+* Matthias Maennich <matthias@maennich.net>
+* Michael Hirsch, Ph.D. <www.scivision.co>
+* Michael Stürmer
+* Miguel A. Figueroa-Villanueva
+* Mike Jackson
+* Mike McQuaid <mike@mikemcquaid.com>
+* Nicolas Bock <nicolasbock@gmail.com>
+* Nicolas Despres <nicolas.despres@gmail.com>
+* Nikita Krupen'ko <krnekit@gmail.com>
+* NVIDIA Corporation <www.nvidia.com>
+* OpenGamma Ltd. <opengamma.com>
+* Patrick Stotko <stotko@cs.uni-bonn.de>
+* Per Øyvind Karlsen <peroyvind@mandriva.org>
+* Peter Collingbourne <peter@pcc.me.uk>
+* Petr Gotthard <gotthard@honeywell.com>
+* Philip Lowman <philip@yhbt.com>
+* Philippe Proulx <pproulx@efficios.com>
+* Raffi Enficiaud, Max Planck Society
+* Raumfeld <raumfeld.com>
+* Roger Leigh <rleigh@codelibre.net>
+* Rolf Eike Beer <eike@sf-mail.de>
+* Roman Donchenko <roman.donchenko@itseez.com>
+* Roman Kharitonov <roman.kharitonov@itseez.com>
+* Ruslan Baratov
+* Sebastian Holtermann <sebholt@xwmw.org>
+* Stephen Kelly <steveire@gmail.com>
+* Sylvain Joubert <joubert.sy@gmail.com>
+* The Qt Company Ltd.
+* Thomas Sondergaard <ts@medical-insight.com>
+* Tobias Hunger <tobias.hunger@qt.io>
+* Todd Gamblin <tgamblin@llnl.gov>
+* Tristan Carel
+* University of Dundee
+* Vadim Zhukov
+* Will Dicharry <wdicharry@stellarscience.com>
+
+See version control history for details of individual contributions.
+
+The above copyright and license notice applies to distributions of
+CMake in source and binary form.  Third-party software packages supplied
+with CMake under compatible licenses provide their own copyright notices
+documented in corresponding subdirectories or source files.
+
+------------------------------------------------------------------------------
+
+CMake was initially developed by Kitware with the following sponsorship:
+
+ * National Library of Medicine at the National Institutes of Health
+   as part of the Insight Segmentation and Registration Toolkit (ITK).
+
+ * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
+   Visualization Initiative.
+
+ * National Alliance for Medical Image Computing (NAMIC) is funded by the
+   National Institutes of Health through the NIH Roadmap for Medical Research,
+   Grant U54 EB005149.
+
+ * Kitware, Inc.
+
+--------------------------------------------------------------------------------
+5. Xbyak_aarch64 (src/cpu/aarch64/xbyak_aarch64/)
+Copyright 2019-2020 FUJITSU LIMITED
+
+Apache License, Version 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+--------------------------------------------------------------------------------
+6. Boost C++ Libraries (src/common/primitive_hashing.hpp)
+Copyright 2005-2014 Daniel James.
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+7. Intel(R) Graphics Compute Runtime for oneAPI Level Zero and OpenCL(TM)
+Driver (src/gpu/jit/ngen/npack/{elf_structs,hash}.hpp)
+Copyright (c) 2018 Intel Corporation
+
+Intel(R) Graphics Compiler (src/gpu/jit/ngen/npack/neo_structs.hpp)
+Copyright (c) 2019 Intel Corporation
+
+oneAPI Level Zero (src/sycl/level_zero)
+Copyright (C) 2019-2021 Intel Corporation
+
+Doxyrest toolkit (doc/doxyrest/*)
+Copyright (c) 2016, Tibbo Technology Inc
+Copyright (c) 2016, Vladimir Gladkov
+Copyright (c) 2016, Doxyrest maintainers
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+8. Sphinx (doc/sphinx/conf/py)
+Copyright (c) 2007-2021 by the Sphinx team (see AUTHORS file).
+All rights reserved.
+
+2-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+9. Intel(R) Metrics Discovery Application Programming Interface (src/gpu/ocl/mdapi/metrics_discovery_api.h)
+MIT License
+
+Copyright (c) 2019, Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/docs/license-libraries/openimagedenoise/third-party-programs-oneTBB.txt
+++ b/docs/license-libraries/openimagedenoise/third-party-programs-oneTBB.txt
@@ -1,0 +1,411 @@
+oneAPI Threading Building Blocks (oneTBB) Third Party Programs File
+
+This file contains the list of third party software ("third party programs")
+contained in the Intel software and their required notices and/or license terms.
+This third party software, even if included with the distribution of the Intel
+software, may be governed by separate license terms, including without limitation,
+third party license terms, other Intel software license terms, and open source
+software license terms. These separate license terms govern your use of the third
+party programs as set forth in the "third-party-programs.txt" or other similarlynamed text file.
+
+The third party programs and their corresponding required notices and/or license
+terms are listed below.
+_______________________________________________________________________________________________________
+
+1.  Intel(R) Instrumentation and Tracing Technology (ITT)
+    Copyright (c) 2022 Intel Corporation. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+    are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors may be
+       used to endorse or promote products derived from this software
+       without specific prior written permission.
+    
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+
+_______________________________________________________________________________________________________
+
+2.  ActiveState Thread pool with same API as (multi)  processing.Pool (Python recipe):
+    Copyright (c) 2008,2016 david decotigny (this file)
+    Copyright (c) 2006-2008, R Oudkerk (multiprocessing.Pool)
+
+    Portable Hardware Locality (hwloc) 
+    Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana University Research and Technology Corporation.  All rights reserved.
+    Copyright (c) 2004-2005 The University of Tennessee and The University of Tennessee Research Foundation.  All rights reserved.
+    Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, University of Stuttgart.  All rights reserved.
+    Copyright (c) 2004-2005 The Regents of the University of California. All rights reserved.
+    Copyright (c) 2009      CNRS
+    Copyright (c) 2009-2016 Inria.  All rights reserved.
+    Copyright (c) 2009-2015 Université Bordeaux
+    Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+    Copyright (c) 2009-2012 Oracle and/or its affiliates.  All rights reserved.
+    Copyright (c) 2010      IBM
+    Copyright (c) 2010      Jirka Hladky
+    Copyright (c) 2012      Aleksej Saushev, The NetBSD Foundation
+    Copyright (c) 2012      Blue Brain Project, EPFL. All rights reserved.
+    Copyright (c) 2013-2014 University of Wisconsin-La Crosse. All rights reserved.
+    Copyright (c) 2015      Research Organization for Information Science and Technology (RIST). All rights reserved.
+    Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+
+    BSD 3-clause "New" or "Revised" License
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of author nor the names of any contributors may be
+       used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+_______________________________________________________________________________________________________
+
+3.  gperftools: Copyright (c) 2011, Google Inc.
+
+    Tachyon: Copyright (c) 1994-2008 John E. Stone. All rights reserved.
+
+    BSD 3-Clause "New" or "Revised" License
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+_______________________________________________________________________________________________________
+
+4.  Mateusz Kwiatkowski Workaround for bug 62258 in libstdc++
+
+    GPL 3.0 with GCC Runtime Library Exception 3.1
+
+	GNU GENERAL PUBLIC LICENSE
+
+	Version 3, 29 June 2007
+
+	Copyright (c) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+	Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+	Preamble
+	The GNU General Public License is a free, copyleft license for software and other kinds of works.
+
+	The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+
+	When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+	To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+
+	For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+	Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+
+	For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+
+	Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+
+	Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+
+	The precise terms and conditions for copying, distribution and modification follow.
+
+	TERMS AND CONDITIONS
+	0. Definitions.
+	"This License" refers to version 3 of the GNU General Public License.
+
+	"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+	"The Program" refers to any copyrightable work licensed under this License. Each licensee is addressed as "you". "Licensees" and "recipients" may be individuals or organizations.
+
+	To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+	A "covered work" means either the unmodified Program or a work based on the Program.
+
+	To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+	To "convey" a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+	An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+	1. Source Code.
+	The "source code" for a work means the preferred form of the work for making modifications to it. "Object code" means any non-source form of a work.
+
+	A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+	The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+	The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+	The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+	The Corresponding Source for a work in source code form is that same work.
+
+	2. Basic Permissions.
+	All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+	You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+	Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+
+	3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+	No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+	When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+	4. Conveying Verbatim Copies.
+	You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+	You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+	5. Conveying Modified Source Versions.
+	You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+	a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+	b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to "keep intact all notices".
+	c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+	d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+	A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+	6. Conveying Non-Source Forms.
+	You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+	a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+	b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+	c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+	d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+	e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+	A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+	A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+	"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+	If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+	The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+	Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+	7. Additional Terms.
+	"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+	When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+	Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+	a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+	b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+	c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+	d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+	e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+	f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+	All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+	If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+	Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+	8. Termination.
+	You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+	However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+	Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+	Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+	9. Acceptance Not Required for Having Copies.
+	You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+	10. Automatic Licensing of Downstream Recipients.
+	Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+
+	An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+	You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+	11. Patents.
+	A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's "contributor version".
+
+	A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+	Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+	In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+	If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+	If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+	A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+	Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+	12. No Surrender of Others' Freedom.
+	If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+	13. Use with the GNU Affero General Public License.
+	Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+
+	14. Revised Versions of this License.
+	The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+	Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+
+	If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+	Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+	15. Disclaimer of Warranty.
+	THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+	16. Limitation of Liability.
+	IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+	17. Interpretation of Sections 15 and 16.
+	If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+	END OF TERMS AND CONDITIONS
+
+	How to Apply These Terms to Your New Programs
+	If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+	To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+		<one line to give the program's name and a brief idea of what it does.>
+		Copyright (C) <year>  <name of author>
+
+		This program is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version.
+
+		This program is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
+
+		You should have received a copy of the GNU General Public License
+		along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	Also add information on how to contact you by electronic and paper mail.
+
+	If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+		<program>  Copyright (C) <year>  <name of author>
+		This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+		This is free software, and you are welcome to redistribute it
+		under certain conditions; type `show c' for details.
+	The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an "about box".
+
+	You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.
+
+	The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read <https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+
+	GCC RUNTIME LIBRARY EXCEPTION
+
+	Version 3.1, 31 March 2009
+
+	Copyright (c) 2009 Free Software Foundation, Inc. <https://fsf.org/>
+
+	Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+	This GCC Runtime Library Exception ("Exception") is an additional permission under section 7 of the GNU General Public License, version 3 ("GPLv3"). It applies to a given file (the "Runtime Library") that bears a notice placed by the copyright holder of the file stating that the file is governed by GPLv3 along with this Exception.
+
+	When you use GCC to compile a program, GCC may combine portions of certain GCC header files and runtime libraries with the compiled program. The purpose of this Exception is to allow compilation of non-GPL (including proprietary) programs to use, in this way, the header files and runtime libraries covered by this Exception.
+
+	0. Definitions.
+	A file is an "Independent Module" if it either requires the Runtime Library for execution after a Compilation Process, or makes use of an interface provided by the Runtime Library, but is not otherwise based on the Runtime Library.
+
+	"GCC" means a version of the GNU Compiler Collection, with or without modifications, governed by version 3 (or a specified later version) of the GNU General Public License (GPL) with the option of using any subsequent versions published by the FSF.
+
+	"GPL-compatible Software" is software whose conditions of propagation, modification and use would permit combination with GCC in accord with the license of GCC.
+
+	"Target Code" refers to output from any compiler for a real or virtual target processor architecture, in executable form or suitable for input to an assembler, loader, linker and/or execution phase. Notwithstanding that, Target Code does not include data in any format that is used as a compiler intermediate representation, or used for producing a compiler intermediate representation.
+
+	The "Compilation Process" transforms code entirely represented in non-intermediate languages designed for human-written code, and/or in Java Virtual Machine byte code, into Target Code. Thus, for example, use of source code generators and preprocessors need not be considered part of the Compilation Process, since the Compilation Process can be understood as starting with the output of the generators or preprocessors.
+
+	A Compilation Process is "Eligible" if it is done using GCC, alone or with other GPL-compatible software, or if it is done without using any work based on GCC. For example, using non-GPL-compatible Software to optimize any GCC intermediate representations would not qualify as an Eligible Compilation Process.
+
+	1. Grant of Additional Permission.
+	You have permission to propagate a work of Target Code formed by combining the Runtime Library with Independent Modules, even if such propagation would otherwise violate the terms of GPLv3, provided that all Target Code was generated by Eligible Compilation Processes. You may then convey such a combination under terms of your choice, consistent with the licensing of the Independent Modules.
+
+	2. No Weakening of GCC Copyleft.
+	The availability of this Exception does not imply any general presumption that third-party software is unaffected by the copyleft requirements of the license of GCC.
+
+_______________________________________________________________________________________________________
+
+5.  Doctest
+
+    Copyright (c) 2016-2021 Viktor Kirilov
+
+    The MIT License (MIT)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+_______________________________________________________________________________________________________
+
+*Other names and brands may be claimed as the property of others.

--- a/docs/license-libraries/openimagedenoise/third-party-programs.txt
+++ b/docs/license-libraries/openimagedenoise/third-party-programs.txt
@@ -1,0 +1,645 @@
+Intel(R) Open Image Denoise Third Party Programs File
+
+This file contains the list of third party software ("third party programs")
+contained in the Intel software and their required notices and/or license
+terms. This third party software, even if included with the distribution of the
+Intel software, may be governed by separate license terms, including without
+limitation, third party license terms, other Intel software license terms, and
+open source software license terms. These separate license terms govern your use
+of the third party programs as set forth in the "third-party-programs.txt" or
+other similarly named text file.
+
+Third party programs and their corresponding required notices and/or license
+terms are listed below.
+
+--------------------------------------------------------------------------------
+
+1.  Intel(R) oneAPI Deep Neural Network Library (oneDNN)
+    Copyright 2016-2023 Intel Corporation
+
+    Intel(R) oneAPI Threading Building Blocks (oneTBB)
+    Copyright 2005-2023 Intel Corporation
+
+    Intel® Embree (snippets)
+    Copyright Intel Corporation
+
+    Intel® OSPRay (snippets)
+    Copyright Intel Corporation
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+2.  PyTorch
+
+    From PyTorch:
+
+    Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+    Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+    Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+    Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+    Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+    Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+    Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+    Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+    Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+
+    From Caffe2:
+
+    Copyright (c) 2016-present, Facebook Inc. All rights reserved.
+
+    All contributions by Facebook:
+    Copyright (c) 2016 Facebook Inc.
+
+    All contributions by Google:
+    Copyright (c) 2015 Google Inc.
+    All rights reserved.
+
+    All contributions by Yangqing Jia:
+    Copyright (c) 2015 Yangqing Jia
+    All rights reserved.
+
+    All contributions from Caffe:
+    Copyright(c) 2013, 2014, 2015, the respective contributors
+    All rights reserved.
+
+    All other contributions:
+    Copyright(c) 2015, 2016 the respective contributors
+    All rights reserved.
+
+    Caffe2 uses a copyright model similar to Caffe: each contributor holds
+    copyright over their contributions to Caffe2. The project versioning records
+    all such contribution and copyright details. If a contributor wants to further
+    mark their specific copyright on a particular contribution, they should
+    indicate their copyright solely in the commit message of the change when it is
+    committed.
+
+    All rights reserved.
+
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America
+   and IDIAP Research Institute nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+3.  pytorch-msssim
+    Copyright (c) 2019 Gongfan Fang
+
+    ROCmSoftwarePlatform/composable_kernel
+    Copyright (c) 2018-    , Advanced Micro Devices, Inc. (Chao Liu, Jing Zhang)
+    Copyright (c) 2019-    , Advanced Micro Devices, Inc. (Letao Qin, Qianfeng Zhang, Liang Huang, Shaojie Wang)
+    Copyright (c) 2022-    , Advanced Micro Devices, Inc. (Anthony Chang, Chunyu Lai, Illia Silin, Adam Osewski, Poyen Chen, Jehandad Khan)
+    Copyright (c) 2019-2021, Advanced Micro Devices, Inc. (Hanwen Chang)
+    Copyright (c) 2019-2020, Advanced Micro Devices, Inc. (Tejash Shah)
+    Copyright (c) 2020     , Advanced Micro Devices, Inc. (Xiaoyan Zhou)
+    Copyright (c) 2021-2022, Advanced Micro Devices, Inc. (Jianfeng Yan)
+    Copyright (c) 2018-2022, Advanced Micro Devices, Inc. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+4.  Catch2
+    Copyright (c) 2021 Two Blue Cubes Ltd. All rights reserved.
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+5.  CUTLASS
+    Copyright (c) 2017 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+6.  oneAPI Data Parallel C++ Compiler
+    Copyright Intel Corporation
+
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+--------------------------------------------------------------------------------
+
+The following third party programs have their own third party programs. These
+additional third party program files are as follows:
+
+1.  Intel(R) oneAPI Deep Neural Network Library (oneDNN)
+      ./third-party-programs-oneDNN.txt
+
+2.  Intel(R) oneAPI Threading Building Blocks (oneTBB)
+      ./third-party-programs-oneTBB.txt
+
+3.  oneAPI DPC++ Compiler
+      ./third-party-programs-DPCPP.txt
+
+--------------------------------------------------------------------------------

--- a/src/Denoiser/Denoiser.hpp
+++ b/src/Denoiser/Denoiser.hpp
@@ -137,6 +137,7 @@ public:
 
     /// Renders the GUI. Returns whether re-rendering has become necessary due to the user's actions.
     virtual bool renderGuiPropertyEditorNodes(sgl::PropertyEditor& propertyEditor) { return false; }
+    virtual void setSettings(const std::unordered_map<std::string, std::string>& settings) {}
 };
 
 enum class DenoisingMode {

--- a/src/Denoiser/Denoiser.hpp
+++ b/src/Denoiser/Denoiser.hpp
@@ -79,6 +79,7 @@ const char* const DENOISER_NAMES[] = {
     FEATURE_MAP(FLOW,                 "Flow",                 2, 2) \
     FEATURE_MAP(POSITION,             "Position",             3, 4) \
     FEATURE_MAP(NORMAL,               "Normal",               3, 4) \
+    FEATURE_MAP(NORMAL_LEN_1,         "Normal (Length 1)",    3, 4) \
     FEATURE_MAP(CLOUDONLY,            "CloudOnly",            4, 4) \
     FEATURE_MAP(DEPTH,                "Depth",                2, 2) \
     FEATURE_MAP(DENSITY,              "Density",              2, 2) \
@@ -125,7 +126,7 @@ public:
     [[nodiscard]] virtual bool getUseFeatureMap(FeatureMapType featureMapType) const = 0;
     [[nodiscard]] virtual bool getWantsAccumulatedInput() const { return true; }
     [[nodiscard]] virtual bool getWantsGlobalFrameNumber() const { return false; }
-    virtual void setUseFeatureMap(FeatureMapType featureMapType, bool useNormals) = 0;
+    virtual void setUseFeatureMap(FeatureMapType featureMapType, bool useFeature) = 0;
     virtual void setTemporalDenoisingEnabled(bool enabled) = 0;
     virtual void resetFrameNumber() = 0; // For temporal denoisers to indicate reset of temporal accumulation.
     virtual void denoise() = 0;

--- a/src/Denoiser/Denoiser.hpp
+++ b/src/Denoiser/Denoiser.hpp
@@ -30,6 +30,7 @@
 #define CLOUDRENDERING_DENOISER_HPP
 
 #include <string>
+#include <unordered_map>
 
 #include <Graphics/Vulkan/Image/Image.hpp>
 

--- a/src/Denoiser/OpenImageDenoiseDenoiser.cpp
+++ b/src/Denoiser/OpenImageDenoiseDenoiser.cpp
@@ -717,3 +717,27 @@ bool OpenImageDenoiseDenoiser::renderGuiPropertyEditorNodes(sgl::PropertyEditor&
 
     return reRender;
 }
+
+void OpenImageDenoiseDenoiser::setSettings(const std::unordered_map<std::string, std::string>& settings) {
+    auto itFilterQuality = settings.find("filter_quality");
+    if (itFilterQuality != settings.end()) {
+        const std::string& filterQualityString = itFilterQuality->second;
+        for (int i = 0; i < IM_ARRAYSIZE(OIDN_QUALITY_NAMES); i++) {
+            if (filterQualityString == OIDN_QUALITY_NAMES[i]) {
+                filterQuality = OIDNQualityCustom(i);
+                recreateFilterNextFrame = true;
+                break;
+            }
+        }
+    }
+    auto itAlbedo = settings.find("use_albedo");
+    if (itAlbedo != settings.end()) {
+        useAlbedo = sgl::fromString<bool>(itAlbedo->second);
+        recreateFilterNextFrame = true;
+    }
+    auto itNormalMal = settings.find("use_normal_map");
+    if (itNormalMal != settings.end()) {
+        useNormalMap = sgl::fromString<bool>(itNormalMal->second);
+        recreateFilterNextFrame = true;
+    }
+}

--- a/src/Denoiser/OpenImageDenoiseDenoiser.cpp
+++ b/src/Denoiser/OpenImageDenoiseDenoiser.cpp
@@ -27,14 +27,25 @@
  */
 
 #include <Math/Math.hpp>
+#include <Utils/AppSettings.hpp>
 #include <Utils/File/Logfile.hpp>
 #include <Graphics/Vulkan/Utils/Device.hpp>
+#include <Graphics/Vulkan/Utils/Swapchain.hpp>
 #include <Graphics/Vulkan/Utils/InteropCustom.hpp>
 #include <Graphics/Vulkan/Buffers/Buffer.hpp>
+#include <Graphics/Vulkan/Render/CommandBuffer.hpp>
 #include <Graphics/Vulkan/Render/Passes/BlitRenderPass.hpp>
 #include <ImGui/Widgets/PropertyEditor.hpp>
 
 #include "OpenImageDenoiseDenoiser.hpp"
+
+#ifdef SUPPORT_CUDA_INTEROP
+#if CUDA_VERSION >= 11020
+#define USE_TIMELINE_SEMAPHORES
+#elif defined(_WIN32)
+#error Binary semaphore sharing is broken on Windows. Please install CUDA >= 11.2 for timeline semaphore support.
+#endif
+#endif
 
 class AlphaBlitPass : public sgl::vk::ComputePass {
 public:
@@ -96,6 +107,26 @@ void AlphaBlitPass::_render() {
 OpenImageDenoiseDenoiser::OpenImageDenoiseDenoiser(sgl::vk::Renderer* renderer, bool _denoiseAlpha)
         : renderer(renderer), denoiseAlpha(_denoiseAlpha) {
     alphaBlitPass = std::make_shared<AlphaBlitPass>(renderer);
+    for (int i = 0; i < IM_ARRAYSIZE(OIDN_DEVICE_TYPE_NAMES) - 2; i++) {
+        deviceTypes.push_back(OIDNDeviceTypeCustom(i));
+        deviceTypeNames.push_back(OIDN_DEVICE_TYPE_NAMES[i]);
+    }
+#ifdef __APPLE__
+    deviceTypes.push_back(OIDNDeviceTypeCustom::METAL);
+    deviceTypeNames.push_back(OIDN_DEVICE_TYPE_NAMES[int(OIDNDeviceTypeCustom::METAL)]);
+#endif
+#ifdef SUPPORT_CUDA_INTEROP
+    sgl::vk::Device* device = renderer->getDevice();
+    if (device->getDeviceDriverId() == VK_DRIVER_ID_NVIDIA_PROPRIETARY
+            && sgl::vk::getIsCudaDeviceApiFunctionTableInitialized()) {
+        // This has the advantage that we do not need to wait for missing OpenImageDenoise semaphore import support.
+        CUresult cuResult = sgl::vk::g_cudaDeviceApiFunctionTable.cuStreamCreate(&cuStream, CU_STREAM_DEFAULT);
+        sgl::vk::checkCUresult(cuResult, "Error in cuStreamCreate: ");
+        // TODO: CUDA_SHARED results in "invalid resource handle", so it is disabled for now.
+        //deviceTypes.push_back(OIDNDeviceTypeCustom::CUDA_SHARED);
+        //deviceTypeNames.push_back(OIDN_DEVICE_TYPE_NAMES[int(OIDNDeviceTypeCustom::CUDA_SHARED)]);
+    }
+#endif
     _createDenoiser();
     _createFilter();
 }
@@ -104,7 +135,40 @@ OpenImageDenoiseDenoiser::~OpenImageDenoiseDenoiser() {
     _freeBuffers();
     _freeFilter();
     _freeDenoiser();
+#ifdef SUPPORT_CUDA_INTEROP
+    sgl::vk::Device* device = renderer->getDevice();
+    if (device->getDeviceDriverId() == VK_DRIVER_ID_NVIDIA_PROPRIETARY
+            && sgl::vk::getIsCudaDeviceApiFunctionTableInitialized()) {
+        CUresult cuResult = sgl::vk::g_cudaDeviceApiFunctionTable.cuStreamDestroy(cuStream);
+        sgl::vk::checkCUresult(cuResult, "Error in cuStreamDestroy: ");
+    }
+#endif
 }
+
+
+#ifdef SUPPORT_CUDA_INTEROP
+CUcontext OpenImageDenoiseDenoiser::cuContext = {};
+CUdevice OpenImageDenoiseDenoiser::cuDevice = 0;
+
+bool OpenImageDenoiseDenoiser::initGlobalCuda(CUcontext _cuContext, CUdevice _cuDevice) {
+    sgl::vk::Device* device = sgl::AppSettings::get()->getPrimaryDevice();
+    if (!device || device->getDeviceDriverId() != VK_DRIVER_ID_NVIDIA_PROPRIETARY) {
+        return false;
+    }
+
+    if (!sgl::vk::getIsCudaDeviceApiFunctionTableInitialized()) {
+        sgl::Logfile::get()->writeInfo(
+                "Error in OpenImageDenoiseDenoiser::initGlobal: sgl::vk::getIsCudaDeviceApiFunctionTableInitialized() "
+                "returned false.");
+        return false;
+    }
+
+    cuContext = _cuContext;
+    cuDevice = _cuDevice;
+
+    return true;
+}
+#endif
 
 
 void OpenImageDenoiseDenoiser::_createDenoiser() {
@@ -116,14 +180,18 @@ void OpenImageDenoiseDenoiser::_createDenoiser() {
         auto* device = renderer->getDevice();
         const VkPhysicalDeviceIDProperties& deviceIdProperties = device->getDeviceIDProperties();
         oidnDevice = oidnNewDeviceByUUID(deviceIdProperties.deviceUUID);
-    } else {
+    }
+#ifdef SUPPORT_CUDA_INTEROP
+    else if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+        // This has the advantage that we do not need to wait for missing OpenImageDenoise semaphore import support.
+        oidnDevice = oidnNewCUDADevice(&cuDevice, &cuStream, 1);
+    }
+#endif
+    else {
         oidnDevice = oidnNewDevice(OIDNDeviceType(std::max(int(deviceType) - 1, 0)));
     }
     oidnCommitDevice(oidnDevice);
 
-    // TODO: If support for manual CUDA is added, use:
-    //oidnNewCUDADevice(deviceIds, streams, 1);
-    // This has the advantage that we do not need to wait for added semaphore import support.
 }
 
 void OpenImageDenoiseDenoiser::_freeDenoiser() {
@@ -131,17 +199,27 @@ void OpenImageDenoiseDenoiser::_freeDenoiser() {
         oidnReleaseDevice(oidnDevice);
         oidnDevice = {};
     }
+#ifdef SUPPORT_CUDA_INTEROP
+    else if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+        // This has the advantage that we do not need to wait for missing OpenImageDenoise semaphore import support.
+        CUresult cuResult = sgl::vk::g_cudaDeviceApiFunctionTable.cuStreamCreate(&cuStream, CU_STREAM_DEFAULT);
+        sgl::vk::checkCUresult(cuResult, "Error in cuStreamCreate: ");
+        oidnNewCUDADevice(&cuDevice, &cuStream, 1);
+    }
+#endif
 }
 
 void OpenImageDenoiseDenoiser::_createFilter() {
     oidnFilter = oidnNewFilter(oidnDevice, "RT");
     oidnSetFilterBool(oidnFilter, "hdr", true);
+    oidnSetFilterInt(oidnFilter, "cleanAux", false);
     oidnSetFilterInt(oidnFilter, "quality", OIDN_QUALITY_MAP[int(filterQuality)]);
 
     if (denoiseAlpha) {
         oidnFilterAlpha = oidnNewFilter(oidnDevice, "RT");
-        oidnSetFilterBool(oidnFilter, "hdr", false);
-        oidnSetFilterInt(oidnFilter, "quality", OIDN_QUALITY_MAP[int(filterQuality)]);
+        oidnSetFilterBool(oidnFilterAlpha, "hdr", false);
+        oidnSetFilterBool(oidnFilterAlpha, "cleanAux", false);
+        oidnSetFilterInt(oidnFilterAlpha, "quality", OIDN_QUALITY_MAP[int(filterQuality)]);
     }
 }
 
@@ -157,12 +235,10 @@ void OpenImageDenoiseDenoiser::_freeFilter() {
 }
 
 void OpenImageDenoiseDenoiser::_createBuffers() {
-
     auto externalMemoryTypes = (OIDNExternalMemoryTypeFlag)oidnGetDeviceInt(oidnDevice, "externalMemoryTypes");
     supportsMemoryImport = false;
 #ifdef __APPLE__
     supportsMemoryImport = true;
-    oidnNewSharedBufferFromMetal(device, buffer->getMetalBufferId()));
 #elif defined(_WIN32)
     if ((externalMemoryTypes & OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32) != 0) {
         supportsMemoryImport = true;
@@ -188,41 +264,68 @@ void OpenImageDenoiseDenoiser::_createBuffers() {
         bufferSettings.useDedicatedAllocationForExportedMemory = true;
 #endif
         inputImageBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
-        inputAlbedoBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
-        inputNormalBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
+        if (useAlbedo) inputAlbedoBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
+        if (useNormalMap) inputNormalBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
         outputImageBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
 #ifndef __APPLE__
-        inputImageBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(inputImageBufferVk);
-        inputAlbedoBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(inputAlbedoBufferVk);
-        inputNormalBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(inputNormalBufferVk);
-        outputImageBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(outputImageBufferVk);
+        if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+#ifdef SUPPORT_CUDA_INTEROP
+            inputImageBufferCu = std::make_shared<sgl::vk::BufferCudaDriverApiExternalMemoryVk>(inputImageBufferVk);
+            if (useAlbedo) inputAlbedoBufferCu = std::make_shared<sgl::vk::BufferCudaDriverApiExternalMemoryVk>(inputAlbedoBufferVk);
+            if (useNormalMap) inputNormalBufferCu = std::make_shared<sgl::vk::BufferCudaDriverApiExternalMemoryVk>(inputNormalBufferVk);
+            outputImageBufferCu = std::make_shared<sgl::vk::BufferCudaDriverApiExternalMemoryVk>(outputImageBufferVk);
 #endif
-#if defined(_WIN32)
+        } else {
+            inputImageBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(inputImageBufferVk);
+            if (useAlbedo) inputAlbedoBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(inputAlbedoBufferVk);
+            if (useNormalMap) inputNormalBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(inputNormalBufferVk);
+            outputImageBufferInterop = std::make_shared<sgl::vk::BufferCustomInteropVk>(outputImageBufferVk);
+        }
+#endif
+#ifdef __APPLE__
+        oidnInputColorBuffer = oidnNewSharedBufferFromMetal(device, inputImageBufferVk->getMetalBufferId()));
+        if (useAlbedo) oidnInputAlbedoBuffer = oidnNewSharedBufferFromMetal(device, inputAlbedoBufferVk->getMetalBufferId()));
+        if (useNormalMap) oidnInputNormalBuffer = oidnNewSharedBufferFromMetal(device, inputNormalBufferVk->getMetalBufferId()));
+        oidnOutputColorBuffer = oidnNewSharedBufferFromMetal(device, outputImageBufferVk->getMetalBufferId()));
+#elif defined(_WIN32)
         oidnInputColorBuffer = oidnNewSharedBufferFromWin32Handle(
                 oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32,
                 inputImageBufferInterop->getHandle(), nullptr, byteSizeColor);
-        oidnInputAlbedoBuffer = oidnNewSharedBufferFromWin32Handle(
+        if (useAlbedo) oidnInputAlbedoBuffer = oidnNewSharedBufferFromWin32Handle(
                 oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32,
                 inputAlbedoBufferInterop->getHandle(), nullptr, byteSizeColor);
-        oidnInputNormalBuffer = oidnNewSharedBufferFromWin32Handle(
+        if (useNormalMap) oidnInputNormalBuffer = oidnNewSharedBufferFromWin32Handle(
                 oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32,
                 inputNormalBufferInterop ->getHandle(), nullptr, byteSizeColor);
         oidnOutputColorBuffer = oidnNewSharedBufferFromWin32Handle(
                 oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32,
                 outputImageBufferInterop->getHandle(), nullptr, byteSizeColor);
 #elif !defined(__APPLE__)
-        oidnInputColorBuffer = oidnNewSharedBufferFromFD(
-                oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
-                inputImageBufferInterop->getFileDescriptor(), byteSizeColor);
-        oidnInputAlbedoBuffer = oidnNewSharedBufferFromFD(
-                oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
-                inputAlbedoBufferInterop->getFileDescriptor(), byteSizeColor);
-        oidnInputNormalBuffer = oidnNewSharedBufferFromFD(
-                oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
-                inputNormalBufferInterop->getFileDescriptor(), byteSizeColor);
-        oidnOutputColorBuffer = oidnNewSharedBufferFromFD(
-                oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
-                outputImageBufferInterop->getFileDescriptor(), byteSizeColor);
+        if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+#ifdef SUPPORT_CUDA_INTEROP
+            oidnInputColorBuffer = oidnNewSharedBuffer(
+                    oidnDevice, reinterpret_cast<void*>(inputImageBufferCu->getCudaDevicePtr()), byteSizeColor);
+            if (useAlbedo) oidnInputAlbedoBuffer = oidnNewSharedBuffer(
+                    oidnDevice, reinterpret_cast<void*>(inputAlbedoBufferCu->getCudaDevicePtr()), byteSizeColor);
+            if (useNormalMap) oidnInputNormalBuffer = oidnNewSharedBuffer(
+                    oidnDevice, reinterpret_cast<void*>(inputNormalBufferCu->getCudaDevicePtr()), byteSizeColor);
+            oidnOutputColorBuffer = oidnNewSharedBuffer(
+                    oidnDevice, reinterpret_cast<void*>(outputImageBufferCu->getCudaDevicePtr()), byteSizeColor);
+#endif
+        } else {
+            oidnInputColorBuffer = oidnNewSharedBufferFromFD(
+                    oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
+                    inputImageBufferInterop->getFileDescriptor(), byteSizeColor);
+            if (useAlbedo) oidnInputAlbedoBuffer = oidnNewSharedBufferFromFD(
+                    oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
+                    inputAlbedoBufferInterop->getFileDescriptor(), byteSizeColor);
+            if (useNormalMap) oidnInputNormalBuffer = oidnNewSharedBufferFromFD(
+                    oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
+                    inputNormalBufferInterop->getFileDescriptor(), byteSizeColor);
+            oidnOutputColorBuffer = oidnNewSharedBufferFromFD(
+                    oidnDevice, OIDN_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD,
+                    outputImageBufferInterop->getFileDescriptor(), byteSizeColor);
+        }
 #endif
     } else {
         sgl::vk::BufferSettings bufferSettings{};
@@ -236,21 +339,18 @@ void OpenImageDenoiseDenoiser::_createBuffers() {
         outputImageBufferVk = std::make_shared<sgl::vk::Buffer>(device, bufferSettings);
 
         oidnInputColorBuffer = oidnNewBuffer(oidnDevice, inputWidth * inputHeight * 4 * sizeof(float));
-        oidnInputAlbedoBuffer = oidnNewBuffer(oidnDevice, inputWidth * inputHeight * 4 * sizeof(float));
-        oidnInputNormalBuffer = oidnNewBuffer(oidnDevice, inputWidth * inputHeight * 4 * sizeof(float));
+        if (useAlbedo) oidnInputAlbedoBuffer = oidnNewBuffer(oidnDevice, inputWidth * inputHeight * 4 * sizeof(float));
+        if (useNormalMap) oidnInputNormalBuffer = oidnNewBuffer(oidnDevice, inputWidth * inputHeight * 4 * sizeof(float));
         oidnOutputColorBuffer = oidnNewBuffer(oidnDevice, inputWidth * inputHeight * 4 * sizeof(float));
     }
-
-    // TODO - For manual CUDA:
-    //oidnNewSharedBuffer(device, devPtr, byteSize);
 
     oidnSetFilterImage(
             oidnFilter, "color",  oidnInputColorBuffer, OIDN_FORMAT_FLOAT3, inputWidth, inputHeight,
             0, 4 * sizeof(float), 0);
-    oidnSetFilterImage(
+    if (useAlbedo) oidnSetFilterImage(
             oidnFilter, "albedo",  oidnInputColorBuffer, OIDN_FORMAT_FLOAT3, inputWidth, inputHeight,
             0, 4 * sizeof(float), 0);
-    oidnSetFilterImage(
+    if (useNormalMap) oidnSetFilterImage(
             oidnFilter, "normal",  oidnInputColorBuffer, OIDN_FORMAT_FLOAT3, inputWidth, inputHeight,
             0, 4 * sizeof(float), 0);
     oidnSetFilterImage(
@@ -262,6 +362,12 @@ void OpenImageDenoiseDenoiser::_createBuffers() {
         oidnSetFilterImage(
                 oidnFilterAlpha, "color",  oidnInputColorBuffer, OIDN_FORMAT_FLOAT, inputWidth, inputHeight,
                 3 * sizeof(float), 4 * sizeof(float), 0);
+        if (useAlbedo) oidnSetFilterImage(
+                oidnFilterAlpha, "albedo",  oidnInputColorBuffer, OIDN_FORMAT_FLOAT3, inputWidth, inputHeight,
+                0, 4 * sizeof(float), 0);
+        if (useNormalMap) oidnSetFilterImage(
+                oidnFilterAlpha, "normal",  oidnInputColorBuffer, OIDN_FORMAT_FLOAT3, inputWidth, inputHeight,
+                0, 4 * sizeof(float), 0);
         oidnSetFilterImage(
                 oidnFilterAlpha, "output", oidnOutputColorBuffer, OIDN_FORMAT_FLOAT, inputWidth, inputHeight,
                 3 * sizeof(float), 4 * sizeof(float), 0);
@@ -301,6 +407,12 @@ void OpenImageDenoiseDenoiser::_freeBuffers() {
     inputAlbedoBufferInterop = {};
     inputNormalBufferInterop = {};
     outputImageBufferInterop = {};
+#ifdef SUPPORT_CUDA_INTEROP
+    inputImageBufferCu = {};
+    inputAlbedoBufferCu = {};
+    inputNormalBufferCu = {};
+    outputImageBufferCu = {};
+#endif
     inputImageBufferVk = {};
     inputAlbedoBufferVk = {};
     inputNormalBufferVk = {};
@@ -375,7 +487,13 @@ void OpenImageDenoiseDenoiser::denoise() {
         recreateFilterNextFrame = false;
     }
     if (recreateBuffersNextFrame) {
-        _createBuffers();
+        if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+            recreateSwapchain(
+                    inputImageVulkan->getImage()->getImageSettings().width,
+                    inputImageVulkan->getImage()->getImageSettings().height);
+        } else {
+            _createBuffers();
+        }
         recreateBuffersNextFrame = false;
     }
 
@@ -394,7 +512,26 @@ void OpenImageDenoiseDenoiser::denoise() {
                 inputNormalBufferVk, renderer->getVkCommandBuffer());
     }
 
-    if (supportsMemoryImport) {
+    if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+#ifdef SUPPORT_CUDA_INTEROP
+        sgl::vk::Swapchain* swapchain = sgl::AppSettings::get()->getSwapchain();
+        uint32_t frameIndex = swapchain ? swapchain->getImageIndex() : 0;
+        timelineValue++;
+        sgl::vk::CommandBufferPtr commandBufferPreDenoise = renderer->getCommandBuffer();
+        auto renderFinishedSemaphore = renderFinishedSemaphores.at(frameIndex);
+#ifdef USE_TIMELINE_SEMAPHORES
+        renderFinishedSemaphore->setSignalSemaphoreValue(timelineValue);
+#endif
+        commandBufferPreDenoise->pushSignalSemaphore(renderFinishedSemaphore);
+        renderer->endCommandBuffer();
+        renderer->submitToQueue();
+#ifdef USE_TIMELINE_SEMAPHORES
+        renderFinishedSemaphore->waitSemaphoreCuda(cuStream, timelineValue);
+#else
+        renderFinishedSemaphore->waitSemaphoreCuda(cuStream);
+#endif
+#endif
+    } else if (supportsMemoryImport) {
         // Sharing semaphores not yet supported. Use device sync.
         renderer->syncWithCpu();
     } else {
@@ -413,7 +550,6 @@ void OpenImageDenoiseDenoiser::denoise() {
 
     if (oidnFilterAlpha) {
         oidnExecuteFilter(oidnFilterAlpha);
-        const char* errorMessage = nullptr;
         if (oidnGetDeviceError(oidnDevice, &errorMessage) != OIDN_ERROR_NONE) {
             sgl::Logfile::get()->throwError(
                     "Error in OpenImageDenoiseDenoiser::denoise[alpha]: " + std::string(errorMessage));
@@ -423,8 +559,30 @@ void OpenImageDenoiseDenoiser::denoise() {
     // Sharing semaphores not yet supported. Use oidnSyncDevice.
     oidnSyncDevice(oidnDevice);
 
+    if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+#ifdef SUPPORT_CUDA_INTEROP
+        sgl::vk::Swapchain* swapchain = sgl::AppSettings::get()->getSwapchain();
+        uint32_t frameIndex = swapchain ? swapchain->getImageIndex() : 0;
+        sgl::vk::CommandBufferPtr postRenderCommandBuffer = postRenderCommandBuffers.at(frameIndex);
+        auto denoiseFinishedSemaphore = denoiseFinishedSemaphores.at(frameIndex);
+#ifdef USE_TIMELINE_SEMAPHORES
+        denoiseFinishedSemaphore->signalSemaphoreCuda(cuStream, timelineValue);
+#else
+        denoiseFinishedSemaphore->signalSemaphoreCuda(cuStream);
+#endif
+#ifdef USE_TIMELINE_SEMAPHORES
+        denoiseFinishedSemaphore->setWaitSemaphoreValue(timelineValue);
+#endif
+        renderer->pushCommandBuffer(postRenderCommandBuffer);
+        renderer->beginCommandBuffer();
+        postRenderCommandBuffer->pushWaitSemaphore(
+                denoiseFinishedSemaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+#endif
+    }
+
     renderer->transitionImageLayout(outputImageVulkan, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     outputImageVulkan->getImage()->copyFromBuffer(outputImageBufferVk, renderer->getVkCommandBuffer());
+
     if (!supportsMemoryImport) {
         renderer->syncWithCpu();
         auto* outputImageBufferVkPtr = reinterpret_cast<float*>(outputImageBufferVk->mapMemory());
@@ -448,6 +606,37 @@ void OpenImageDenoiseDenoiser::recreateSwapchain(uint32_t width, uint32_t height
     _createBuffers();
     alphaBlitPass->setInputImage(inputImageVulkan);
     alphaBlitPass->setOutputImage(outputImageVulkan);
+
+#ifdef SUPPORT_CUDA_INTEROP
+    if (deviceType == OIDNDeviceTypeCustom::CUDA_SHARED) {
+        sgl::vk::Device* device = renderer->getDevice();
+        sgl::vk::Swapchain* swapchain = sgl::AppSettings::get()->getSwapchain();
+        size_t numImages = swapchain ? swapchain->getNumImages() : 1;
+
+        postRenderCommandBuffers.clear();
+        renderFinishedSemaphores.clear();
+        denoiseFinishedSemaphores.clear();
+        sgl::vk::CommandPoolType commandPoolType;
+        commandPoolType.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        if (!swapchain) {
+            commandPoolType.queueFamilyIndex = device->getComputeQueueIndex();
+        }
+        for (size_t frameIdx = 0; frameIdx < numImages; frameIdx++) {
+            postRenderCommandBuffers.push_back(std::make_shared<sgl::vk::CommandBuffer>(device, commandPoolType));
+#ifdef USE_TIMELINE_SEMAPHORES
+            denoiseFinishedSemaphores.push_back(std::make_shared<sgl::vk::SemaphoreVkCudaDriverApiInterop>(
+                    device, 0, VK_SEMAPHORE_TYPE_TIMELINE,
+                    timelineValue));
+            renderFinishedSemaphores.push_back(std::make_shared<sgl::vk::SemaphoreVkCudaDriverApiInterop>(
+                    device, 0, VK_SEMAPHORE_TYPE_TIMELINE,
+                    timelineValue));
+#else
+            denoiseFinishedSemaphores.push_back(std::make_shared<sgl::vk::SemaphoreVkCudaDriverApiInterop>(device));
+            renderFinishedSemaphores.push_back(std::make_shared<sgl::vk::SemaphoreVkCudaDriverApiInterop>(device));
+#endif
+        }
+    }
+#endif
 }
 
 
@@ -455,7 +644,8 @@ bool OpenImageDenoiseDenoiser::renderGuiPropertyEditorNodes(sgl::PropertyEditor&
     bool reRender = false;
 
     if (propertyEditor.addCombo(
-            "Denoiser Device", (int*)&deviceType, OIDN_DEVICE_TYPE_NAMES, IM_ARRAYSIZE(OIDN_DEVICE_TYPE_NAMES))) {
+            "Denoiser Device", &deviceTypeIdx, deviceTypeNames.data(), int(deviceTypeNames.size()))) {
+        deviceType = deviceTypes.at(deviceTypeIdx);
         reRender = true;
         recreateDenoiserNextFrame = true;
     }
@@ -466,15 +656,28 @@ bool OpenImageDenoiseDenoiser::renderGuiPropertyEditorNodes(sgl::PropertyEditor&
         recreateFilterNextFrame = true;
     }
 
-    if (propertyEditor.addCheckbox("Use Albedo", &useAlbedo)) {
+    // OpenImageDenoise doesn't support only normal map and then raises "unsupported combination of input features".
+    OIDNFeatureMaps featureMaps = OIDNFeatureMaps::NONE;
+    if (useNormalMap) {
+        featureMaps = OIDNFeatureMaps::ALBEDO_NORMAL;
+    } else if (useAlbedo) {
+        featureMaps = OIDNFeatureMaps::ALBEDO;
+    }
+    if (propertyEditor.addCombo(
+            "Feature Maps", (int*)&featureMaps, OIDN_FEATURE_MAP_NAMES, IM_ARRAYSIZE(OIDN_FEATURE_MAP_NAMES))) {
+        reRender = true;
+        recreateBuffersNextFrame = true;
+        useAlbedo = featureMaps == OIDNFeatureMaps::ALBEDO_NORMAL || featureMaps == OIDNFeatureMaps::ALBEDO;
+        useNormalMap = featureMaps == OIDNFeatureMaps::ALBEDO_NORMAL;
+    }
+    /*if (propertyEditor.addCheckbox("Use Albedo", &useAlbedo)) {
         reRender = true;
         recreateBuffersNextFrame = true;
     }
-
     if (propertyEditor.addCheckbox("Use Normal Map", &useNormalMap)) {
         reRender = true;
         recreateBuffersNextFrame = true;
-    }
+    }*/
 
     if (propertyEditor.addCheckbox("Use Alpha", &denoiseAlpha)) {
         reRender = true;

--- a/src/Denoiser/OpenImageDenoiseDenoiser.cpp
+++ b/src/Denoiser/OpenImageDenoiseDenoiser.cpp
@@ -740,4 +740,11 @@ void OpenImageDenoiseDenoiser::setSettings(const std::unordered_map<std::string,
         useNormalMap = sgl::fromString<bool>(itNormalMal->second);
         recreateFilterNextFrame = true;
     }
+
+    if (recreateDenoiserNextFrame) {
+        recreateFilterNextFrame = true;
+    }
+    if (recreateFilterNextFrame) {
+        recreateBuffersNextFrame = true;
+    }
 }

--- a/src/Denoiser/OpenImageDenoiseDenoiser.cpp
+++ b/src/Denoiser/OpenImageDenoiseDenoiser.cpp
@@ -108,6 +108,7 @@ OpenImageDenoiseDenoiser::OpenImageDenoiseDenoiser(sgl::vk::Renderer* renderer, 
         : renderer(renderer), denoiseAlpha(_denoiseAlpha) {
     alphaBlitPass = std::make_shared<AlphaBlitPass>(renderer);
     for (int i = 0; i < IM_ARRAYSIZE(OIDN_DEVICE_TYPE_NAMES) - 2; i++) {
+        // TODO: Use oidnIsCPUDeviceSupported, ...
         deviceTypes.push_back(OIDNDeviceTypeCustom(i));
         deviceTypeNames.push_back(OIDN_DEVICE_TYPE_NAMES[i]);
     }

--- a/src/Denoiser/OpenImageDenoiseDenoiser.cpp
+++ b/src/Denoiser/OpenImageDenoiseDenoiser.cpp
@@ -190,8 +190,14 @@ void OpenImageDenoiseDenoiser::_createDenoiser() {
     else {
         oidnDevice = oidnNewDevice(OIDNDeviceType(std::max(int(deviceType) - 1, 0)));
     }
+    if (!oidnDevice) {
+        const char* errorMessage = nullptr;
+        if (oidnGetDeviceError(oidnDevice, &errorMessage) != OIDN_ERROR_NONE) {
+            sgl::Logfile::get()->throwError(
+                    "Error in OpenImageDenoiseDenoiser::_createDenoiser: " + std::string(errorMessage));
+        }
+    }
     oidnCommitDevice(oidnDevice);
-
 }
 
 void OpenImageDenoiseDenoiser::_freeDenoiser() {

--- a/src/Denoiser/OpenImageDenoiseDenoiser.hpp
+++ b/src/Denoiser/OpenImageDenoiseDenoiser.hpp
@@ -96,6 +96,7 @@ public:
 
     /// Renders the GUI. Returns whether re-rendering has become necessary due to the user's actions.
     bool renderGuiPropertyEditorNodes(sgl::PropertyEditor& propertyEditor) override;
+    void setSettings(const std::unordered_map<std::string, std::string>& settings) override;
 
 private:
     sgl::vk::Renderer* renderer = nullptr;

--- a/src/Denoiser/OptixVptDenoiser.cpp
+++ b/src/Denoiser/OptixVptDenoiser.cpp
@@ -156,8 +156,8 @@ void OptixVptDenoiser::createDenoiser() {
     }
 
     OptixDenoiserOptions options;
-    options.guideAlbedo = useAlbedo && albedoImageVulkan ? 1 : 0;
-    options.guideNormal = useNormalMap && normalImageVulkan ? 1 : 0;
+    options.guideAlbedo = useAlbedo ? 1 : 0;
+    options.guideNormal = useNormalMap ? 1 : 0;
 #if OPTIX_VERSION >= 80000
     options.denoiseAlpha = denoiseAlpha ? OPTIX_DENOISER_ALPHA_MODE_COPY : OPTIX_DENOISER_ALPHA_MODE_DENOISE;
 #endif
@@ -286,7 +286,7 @@ void OptixVptDenoiser::recreateSwapchain(uint32_t width, uint32_t height) {
     inputImageOptix.rowStrideInBytes = inputWidth * 4 * sizeof(float);
     inputImageOptix.data = inputImageBufferCu->getCudaDevicePtr();
 
-    if (useAlbedo && albedoImageVulkan) {
+    if (useAlbedo) {
         albedoImageBufferCu = {};
         albedoImageBufferVk = std::make_shared<sgl::vk::Buffer>(
                 device, inputWidth * inputHeight * 4 * sizeof(float),
@@ -304,7 +304,7 @@ void OptixVptDenoiser::recreateSwapchain(uint32_t width, uint32_t height) {
         albedoImageOptix.data = albedoImageBufferCu->getCudaDevicePtr();
     }
 
-    if (useNormalMap && normalImageVulkan) {
+    if (useNormalMap) {
         normalImageBufferCu = {};
         normalImageBufferVk = std::make_shared<sgl::vk::Buffer>(
                 device, inputWidth * inputHeight * 3 * sizeof(float),

--- a/src/Denoiser/OptixVptDenoiser.cpp
+++ b/src/Denoiser/OptixVptDenoiser.cpp
@@ -186,7 +186,7 @@ void OptixVptDenoiser::setOutputImage(sgl::vk::ImageViewPtr& outputImage) {
 void OptixVptDenoiser::setFeatureMap(FeatureMapType featureMapType, const sgl::vk::TexturePtr& featureTexture) {
     if (featureMapType == FeatureMapType::COLOR) {
         inputImageVulkan = featureTexture->getImageView();
-    } else if (featureMapType == FeatureMapType::NORMAL) {
+    } else if (featureMapType == FeatureMapType::NORMAL_LEN_1) {
         normalImageVulkan = featureTexture->getImageView();
     } else if (featureMapType == FeatureMapType::ALBEDO) {
         albedoImageVulkan = featureTexture->getImageView();
@@ -204,7 +204,7 @@ bool OptixVptDenoiser::getUseFeatureMap(FeatureMapType featureMapType) const {
         return true;
     } else if (featureMapType == FeatureMapType::ALBEDO) {
         return useAlbedo;
-    } else if (featureMapType == FeatureMapType::NORMAL) {
+    } else if (featureMapType == FeatureMapType::NORMAL_LEN_1) {
         return useNormalMap;
     } else if (featureMapType == FeatureMapType::FLOW) {
         return denoiserModelKind == OPTIX_DENOISER_MODEL_KIND_TEMPORAL;
@@ -215,7 +215,7 @@ bool OptixVptDenoiser::getUseFeatureMap(FeatureMapType featureMapType) const {
 
 void OptixVptDenoiser::setUseFeatureMap(FeatureMapType featureMapType, bool useFeature) {
     if ((featureMapType == FeatureMapType::ALBEDO && useAlbedo != useFeature)
-            || (featureMapType == FeatureMapType::NORMAL && useNormalMap != useFeature)
+            || (featureMapType == FeatureMapType::NORMAL_LEN_1 && useNormalMap != useFeature)
             || (featureMapType == FeatureMapType::FLOW && getUseFeatureMap(FeatureMapType::FLOW) != useFeature)) {
         recreateDenoiserNextFrame = true;
     }
@@ -226,7 +226,7 @@ void OptixVptDenoiser::setUseFeatureMap(FeatureMapType featureMapType, bool useF
         }
     } else if (featureMapType == FeatureMapType::ALBEDO) {
         useAlbedo = useFeature;
-    } else if (featureMapType == FeatureMapType::NORMAL) {
+    } else if (featureMapType == FeatureMapType::NORMAL_LEN_1) {
         useNormalMap = useFeature;
     } else if (featureMapType == FeatureMapType::FLOW) {
         denoiserModelKind = useFeature ? OPTIX_DENOISER_MODEL_KIND_HDR : OPTIX_DENOISER_MODEL_KIND_TEMPORAL;

--- a/src/Denoiser/OptixVptDenoiser.cpp
+++ b/src/Denoiser/OptixVptDenoiser.cpp
@@ -562,7 +562,7 @@ bool OptixVptDenoiser::renderGuiPropertyEditorNodes(sgl::PropertyEditor& propert
     bool reRender = false;
 
     if (propertyEditor.addCombo(
-            "Feature Map", (int*)&denoiserModelKindIndex,
+            "Model Type", (int*)&denoiserModelKindIndex,
             OPTIX_DENOISER_MODEL_KIND_NAME, numDenoisersSupported)) {
         reRender = true;
         if (denoiserModelKindIndex == 0) {
@@ -590,6 +590,30 @@ bool OptixVptDenoiser::renderGuiPropertyEditorNodes(sgl::PropertyEditor& propert
     }
 
     return reRender;
+}
+
+void OptixVptDenoiser::setSettings(const std::unordered_map<std::string, std::string>& settings) {
+    auto itModelType = settings.find("model_type");
+    if (itModelType != settings.end()) {
+        const std::string& modelTypeString = itModelType->second;
+        for (int i = 0; i < IM_ARRAYSIZE(OPTIX_DENOISER_MODEL_KIND_NAME); i++) {
+            if (modelTypeString == OPTIX_DENOISER_MODEL_KIND_NAME[i]) {
+                denoiserModelKindIndex = i;
+                recreateDenoiserNextFrame = true;
+                break;
+            }
+        }
+    }
+    auto itAlbedo = settings.find("use_albedo");
+    if (itAlbedo != settings.end()) {
+        useAlbedo = sgl::fromString<bool>(itAlbedo->second);
+        recreateDenoiserNextFrame = true;
+    }
+    auto itNormalMal = settings.find("use_normal_map");
+    if (itNormalMal != settings.end()) {
+        useNormalMap = sgl::fromString<bool>(itNormalMal->second);
+        recreateDenoiserNextFrame = true;
+    }
 }
 
 

--- a/src/Denoiser/OptixVptDenoiser.cpp
+++ b/src/Denoiser/OptixVptDenoiser.cpp
@@ -156,8 +156,8 @@ void OptixVptDenoiser::createDenoiser() {
     }
 
     OptixDenoiserOptions options;
-    options.guideAlbedo = useAlbedo ? 1 : 0;
-    options.guideNormal = useNormalMap ? 1 : 0;
+    options.guideAlbedo = useAlbedo && albedoImageVulkan ? 1 : 0;
+    options.guideNormal = useNormalMap && normalImageVulkan ? 1 : 0;
 #if OPTIX_VERSION >= 80000
     options.denoiseAlpha = denoiseAlpha ? OPTIX_DENOISER_ALPHA_MODE_COPY : OPTIX_DENOISER_ALPHA_MODE_DENOISE;
 #endif
@@ -286,7 +286,7 @@ void OptixVptDenoiser::recreateSwapchain(uint32_t width, uint32_t height) {
     inputImageOptix.rowStrideInBytes = inputWidth * 4 * sizeof(float);
     inputImageOptix.data = inputImageBufferCu->getCudaDevicePtr();
 
-    if (useAlbedo) {
+    if (useAlbedo && albedoImageVulkan) {
         albedoImageBufferCu = {};
         albedoImageBufferVk = std::make_shared<sgl::vk::Buffer>(
                 device, inputWidth * inputHeight * 4 * sizeof(float),
@@ -304,7 +304,7 @@ void OptixVptDenoiser::recreateSwapchain(uint32_t width, uint32_t height) {
         albedoImageOptix.data = albedoImageBufferCu->getCudaDevicePtr();
     }
 
-    if (useNormalMap) {
+    if (useNormalMap && normalImageVulkan) {
         normalImageBufferCu = {};
         normalImageBufferVk = std::make_shared<sgl::vk::Buffer>(
                 device, inputWidth * inputHeight * 3 * sizeof(float),

--- a/src/Denoiser/OptixVptDenoiser.hpp
+++ b/src/Denoiser/OptixVptDenoiser.hpp
@@ -72,6 +72,7 @@ public:
 
     /// Renders the GUI. Returns whether re-rendering has become necessary due to the user's actions.
     bool renderGuiPropertyEditorNodes(sgl::PropertyEditor& propertyEditor) override;
+    void setSettings(const std::unordered_map<std::string, std::string>& settings) override;
 
 private:
     sgl::vk::Renderer* renderer = nullptr;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -102,8 +102,8 @@ int main(int argc, char *argv[]) {
     sgl::Window* window = sgl::AppSettings::get()->createWindow();
 
     std::vector<const char*> optionalDeviceExtensions;
-#ifdef SUPPORT_CUDA_INTEROP
-    optionalDeviceExtensions = sgl::vk::Device::getCudaInteropDeviceExtensions();
+#if defined(SUPPORT_CUDA_INTEROP) || defined(SUPPORT_OPEN_IMAGE_DENOISE)
+    optionalDeviceExtensions = sgl::vk::Device::getVulkanInteropDeviceExtensions();
 #endif
     optionalDeviceExtensions.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 

--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -56,6 +56,9 @@
 #ifdef SUPPORT_OPTIX
 #include "Denoiser/OptixVptDenoiser.hpp"
 #endif
+#if defined(SUPPORT_CUDA_INTEROP) && defined(SUPPORT_OPEN_IMAGE_DENOISE)
+#include "Denoiser/OpenImageDenoiseDenoiser.hpp"
+#endif
 #include "DataView.hpp"
 #include "MainApp.hpp"
 
@@ -107,6 +110,11 @@ MainApp::MainApp()
 #ifdef SUPPORT_OPTIX
     if (cudaInteropInitialized) {
         optixInitialized = OptixVptDenoiser::initGlobal(cuContext, cuDevice);
+    }
+#endif
+#if defined(SUPPORT_CUDA_INTEROP) && defined(SUPPORT_OPEN_IMAGE_DENOISE)
+    if (cudaInteropInitialized) {
+        OpenImageDenoiseDenoiser::initGlobalCuda(cuContext, cuDevice);
     }
 #endif
 

--- a/src/PathTracer/VolumetricPathTracingPass.cpp
+++ b/src/PathTracer/VolumetricPathTracingPass.cpp
@@ -1710,7 +1710,10 @@ void VolumetricPathTracingPass::checkRecreateDenoiser() {
 }
 
 void VolumetricPathTracingPass::_render() {
-    checkRecreateDenoiser();
+    bool useDenoiserThisFrame = featureMapSet.find(FeatureMapTypeVpt::TRANSMITTANCE_VOLUME) == featureMapSet.end();
+    if (useDenoiserThisFrame) {
+        checkRecreateDenoiser();
+    }
 
     std::string eventName = getCurrentEventName();
     if (createNewAccumulationTimer) {
@@ -2009,7 +2012,7 @@ void VolumetricPathTracingPass::_render() {
     timerStopped = false;
 
     if (featureMapType == FeatureMapTypeVpt::RESULT) {
-        if (useDenoiser && denoiser && denoiser->getIsEnabled() && !isIntermediatePass) {
+        if (useDenoiser && useDenoiserThisFrame && denoiser && denoiser->getIsEnabled() && !isIntermediatePass) {
             if (!reachedTarget){
                 denoiseTimer->startGPU("denoise");
                 accumulationTimer->startGPU("denoise");

--- a/src/PathTracer/VolumetricPathTracingPass.cpp
+++ b/src/PathTracer/VolumetricPathTracingPass.cpp
@@ -1069,7 +1069,7 @@ void VolumetricPathTracingPass::setEnvMapRotCamera() {
         useEnvMapRot = true;
         setShaderDirty();
     }
-    useEnvMapRotCamera = false;
+    useEnvMapRotCamera = true;
     reRender = true;
     frameInfo.frameCount = 0;
 }

--- a/src/PathTracer/VolumetricPathTracingPass.cpp
+++ b/src/PathTracer/VolumetricPathTracingPass.cpp
@@ -942,9 +942,17 @@ void VolumetricPathTracingPass::setFileDialogInstance(ImGuiFileDialog* _fileDial
 void VolumetricPathTracingPass::setDenoiserType(DenoiserType _denoiserType) {
     if (denoiserType != _denoiserType) {
         denoiserType = _denoiserType;
+        denoiserSettings = {};
         denoiserChanged = true;
         reRender = true;
     }
+}
+
+void VolumetricPathTracingPass::setDenoiserSettings(
+        const std::unordered_map<std::string, std::string>& _denoiserSettings) {
+    denoiserSettings = _denoiserSettings;
+    denoiserSettingsChanged = true;
+    reRender = true;
 }
 
 void VolumetricPathTracingPass::setPyTorchDenoiserModelFilePath(const std::string& denoiserModelFilePath) {
@@ -1692,6 +1700,12 @@ void VolumetricPathTracingPass::checkRecreateDenoiser() {
     if (denoiserChanged) {
         createDenoiser();
         denoiserChanged = false;
+    }
+    if (denoiserSettingsChanged) {
+        if (denoiser) {
+            denoiser->setSettings(denoiserSettings);
+        }
+        denoiserSettingsChanged = false;
     }
 }
 

--- a/src/PathTracer/VolumetricPathTracingPass.hpp
+++ b/src/PathTracer/VolumetricPathTracingPass.hpp
@@ -197,6 +197,11 @@ public:
     [[nodiscard]] IsosurfaceType getIsosurfaceType() const { return isosurfaceType; }
     [[nodiscard]] bool getUseIsosurfaceTf() const { return useIsosurfaceTf; }
 
+    // Clip Plane
+    void setUseClipPlane(bool useClipPlane);
+    void setClipPlaneNormal(const glm::vec3& clipPlaneNormal);
+    void setClipPlaneDistance(float clipPlaneDistance);
+
     // For debug rendering.
     void setCameraPoses(const std::vector<CameraPose>& cameraPoses);
 
@@ -375,6 +380,11 @@ private:
     bool useEmptySpaceSkipping = false;
     std::shared_ptr<OccupancyGridPass> occupancyGridPass;
 
+    // Clip Plane
+    bool useClipPlane = false;
+    glm::vec3 clipPlaneNormal = glm::vec3(1.0f, 0.0f, 0.0f);
+    float clipPlaneDistance = 0.0f;
+
     glm::mat4 previousViewProjMatrix = glm::zero<glm::mat4>();
 
     // Disney BRDF
@@ -443,6 +453,11 @@ private:
         float isoStepWidth = 0.25f;
         float maxAoDist = 0.05f;
         int numAoSamples = 4;
+
+        // Clip Plane
+        int useClipPlane;
+        glm::vec3 clipPlaneNormal;
+        float clipPlaneDistance;
 
         // Disney BRDF
         float subsurface = 0.0;

--- a/src/PathTracer/VolumetricPathTracingPass.hpp
+++ b/src/PathTracer/VolumetricPathTracingPass.hpp
@@ -57,6 +57,7 @@ class OctahedralMappingPass;
 class OccupationVolumePass;
 class OccupancyGridPass;
 class CameraPoseLinePass;
+class NormalizeNormalsPass;
 
 namespace IGFD {
 class FileDialog;
@@ -64,13 +65,15 @@ class FileDialog;
 typedef IGFD::FileDialog ImGuiFileDialog;
 
 enum class FeatureMapTypeVpt {
-    RESULT, FIRST_X, FIRST_W, NORMAL, CLOUD_ONLY, DEPTH, FLOW, DEPTH_NABLA, DEPTH_FWIDTH,
-    DENSITY, BACKGROUND, REPROJ_UV, DEPTH_BLENDED, DEPTH_NEAREST_OPAQUE, TRANSMITTANCE_VOLUME,
+    RESULT, FIRST_X, FIRST_W, NORMAL, NORMAL_LEN_1, CLOUD_ONLY, DEPTH, FLOW, DEPTH_NABLA,
+    DEPTH_FWIDTH, DENSITY, BACKGROUND, REPROJ_UV, DEPTH_BLENDED, DEPTH_NEAREST_OPAQUE, ALBEDO,
+    TRANSMITTANCE_VOLUME,
     PRIMARY_RAY_ABSORPTION_MOMENTS, SCATTER_RAY_ABSORPTION_MOMENTS
 };
 const char* const VPT_FEATURE_MAP_NAMES[] = {
-        "Result", "First X", "First W", "Normal", "Cloud Only", "Depth", "Flow", "Depth (nabla)", "Depth (fwidth)",
-        "Density", "Background", "Reprojected UV", "Depth Blended", "Depth Nearest Opaque", "Transmittance Volume",
+        "Result", "First X", "First W", "Normal", "Normal (Length 1)", "Cloud Only", "Depth", "Flow", "Depth (nabla)",
+        "Depth (fwidth)", "Density", "Background", "Reprojected UV", "Depth Blended", "Depth Nearest Opaque", "Albedo",
+        "Transmittance Volume",
         "Primary Ray Absorption Moments", "Scatter Ray Absorption Moments"
 };
 
@@ -104,7 +107,7 @@ private:
 
 const FeatureMapCorrespondence featureMapCorrespondence({
         {FeatureMapType::COLOR, FeatureMapTypeVpt::RESULT},
-        {FeatureMapType::ALBEDO, FeatureMapTypeVpt::RESULT},
+        {FeatureMapType::ALBEDO, FeatureMapTypeVpt::ALBEDO},
         {FeatureMapType::FLOW, FeatureMapTypeVpt::FLOW},
         {FeatureMapType::POSITION, FeatureMapTypeVpt::FIRST_X},
         {FeatureMapType::NORMAL, FeatureMapTypeVpt::NORMAL},
@@ -274,6 +277,7 @@ private:
     sgl::vk::TexturePtr firstXTexture;
     sgl::vk::TexturePtr firstWTexture;
     sgl::vk::TexturePtr normalTexture;
+    sgl::vk::TexturePtr normalLen1Texture;
     sgl::vk::TexturePtr cloudOnlyTexture;
     sgl::vk::TexturePtr depthTexture;
     sgl::vk::TexturePtr densityTexture;
@@ -284,6 +288,7 @@ private:
     sgl::vk::TexturePtr flowTexture;
     sgl::vk::TexturePtr depthNablaTexture;
     sgl::vk::TexturePtr depthFwidthTexture;
+    sgl::vk::TexturePtr albedoTexture;
     sgl::vk::TexturePtr transmittanceVolumeTexture; //< 3D feature map.
     uint32_t dsSecondaryVolume = 1; //< Downscaling factor for secondary volumes like @see transmittanceVolumeTexture.
     bool accumulateInputs = true;
@@ -337,6 +342,7 @@ private:
     glm::vec3 headlightColor = glm::vec3(1.0f, 0.961538462f, 0.884615385f);
     float headlightIntensity = 0.5f;
 
+    std::shared_ptr<NormalizeNormalsPass> normalizeNormalsPass;
     sgl::vk::BlitRenderPassPtr blitResultRenderPass;
     // Use the two passes below if a compute queue is used and raster-blitting is not available.
     sgl::vk::BlitComputePassPtr resultImageBlitPass;

--- a/src/PathTracer/VolumetricPathTracingPass.hpp
+++ b/src/PathTracer/VolumetricPathTracingPass.hpp
@@ -157,6 +157,7 @@ public:
 
     // Environment
     void disableEnvMapRot();
+    void setEnvMapRotCamera();
     void setEnvMapRotEulerAngles(const glm::vec3& _eulerAngles);
     void setEnvMapRotYawPitchRoll(const glm::vec3& _yawPitchRoll);
     void setEnvMapRotAngleAxis(const glm::vec3& _axis, float _angle);
@@ -319,6 +320,7 @@ private:
     float environmentMapIntensityFactor = 1;
     glm::vec3 environmentMapIntensityFactorRgb = glm::vec3(1.0f);
     bool useEnvMapRot = false;
+    bool useEnvMapRotCamera = false; ///< Align envmap with camera orientation.
     glm::mat3 envMapRot = glm::identity<glm::mat3>();
     RotationWidget envMapRotWidget;
     bool useTransferFunctionCached = false;

--- a/src/PathTracer/VolumetricPathTracingPass.hpp
+++ b/src/PathTracer/VolumetricPathTracingPass.hpp
@@ -144,6 +144,7 @@ public:
     void setUseLinearRGB(bool useLinearRGB);
     void setFileDialogInstance(ImGuiFileDialog* _fileDialogInstance);
     void setDenoiserType(DenoiserType denoiserType);
+    void setDenoiserSettings(const std::unordered_map<std::string, std::string>& denoiserSettings);
     void checkRecreateDenoiser();
     void setPyTorchDenoiserModelFilePath(const std::string& denoiserModelFilePath);
     void setOutputForegroundMap(bool _shallOutputForegroundMap);
@@ -358,9 +359,10 @@ private:
     void setDenoiserFeatureMaps();
     void checkResetDenoiserFeatureMaps();
     DenoiserType denoiserType = DenoiserType::EAW;
+    std::unordered_map<std::string, std::string> denoiserSettings;
     bool useDenoiser = true;
     bool isIntermediatePass = false; //< Whether this rendering pass should not yet use the denoiser.
-    bool denoiserChanged = false;
+    bool denoiserChanged = false, denoiserSettingsChanged = false;
     bool denoiseAlpha = false;
     bool shallOutputForegroundMap = false;
     std::shared_ptr<Denoiser> denoiser;

--- a/src/PyTorch/Module.cpp
+++ b/src/PyTorch/Module.cpp
@@ -103,6 +103,9 @@ TORCH_LIBRARY(vpt, m) {
     m.def("vpt::set_surface_brdf", setSurfaceBrdf);
     m.def("vpt::set_use_isosurface_tf", setUseIsosurfaceTf);
     m.def("vpt::set_num_isosurface_subdivisions", setNumIsosurfaceSubdivisions);
+    m.def("vpt::set_use_clip_plane", setUseClipPlane);
+    m.def("vpt::set_clip_plane_normal", setClipPlaneNormal);
+    m.def("vpt::set_clip_plane_distance", setClipPlaneDistance);
     m.def("vpt::set_seed_offset", setSeedOffset);
     m.def("vpt::set_use_feature_maps", setUseFeatureMaps);
     m.def("vpt::get_feature_map", getFeatureMap);
@@ -851,6 +854,21 @@ void setUseIsosurfaceTf(bool _useIsosurfaceTf) {
 
 void setNumIsosurfaceSubdivisions(int64_t _subdivs) {
     vptRenderer->getVptPass()->setNumIsosurfaceSubdivisions(_subdivs);
+}
+
+void setUseClipPlane(bool _useClipPlane) {
+    vptRenderer->getVptPass()->setUseClipPlane(_useClipPlane);
+}
+
+void setClipPlaneNormal(std::vector<double> _clipPlaneNormal) {
+    glm::vec3 normal = glm::vec3(0,0,0);
+    if (parseVector3(_clipPlaneNormal, normal)) {
+        vptRenderer->getVptPass()->setClipPlaneNormal(normal);
+    }
+}
+
+void setClipPlaneDistance(double _clipPlaneDistance) {
+    vptRenderer->getVptPass()->setClipPlaneDistance(_clipPlaneDistance);
 }
 
 

--- a/src/PyTorch/Module.cpp
+++ b/src/PyTorch/Module.cpp
@@ -67,6 +67,7 @@ TORCH_LIBRARY(vpt, m) {
     m.def("vpt::set_environment_map_intensity", setEnvironmentMapIntensityFactor);
     m.def("vpt::set_environment_map_intensity_rgb", setEnvironmentMapIntensityFactorRgb);
     m.def("vpt::disable_env_map_rot", disableEnvMapRot);
+    m.def("vpt::set_env_map_rot_camera", setEnvMapRotCamera);
     m.def("vpt::set_env_map_rot_euler_angles", setEnvMapRotEulerAngles);
     m.def("vpt::set_env_map_rot_yaw_pitch_roll", setEnvMapRotYawPitchRoll);
     m.def("vpt::set_env_map_rot_angle_axis", setEnvMapRotAngleAxis);
@@ -689,6 +690,10 @@ void setEnvironmentMapIntensityFactorRgb(std::vector<double> intensityFactor) {
 
 void disableEnvMapRot() {
     vptRenderer->getVptPass()->disableEnvMapRot();
+}
+
+void setEnvMapRotCamera() {
+    vptRenderer->getVptPass()->setEnvMapRotCamera();
 }
 
 void setEnvMapRotEulerAngles(std::vector<double> eulerAnglesVec) {

--- a/src/PyTorch/Module.cpp
+++ b/src/PyTorch/Module.cpp
@@ -78,6 +78,7 @@ TORCH_LIBRARY(vpt, m) {
     m.def("vpt::set_vpt_mode", setVPTMode);
     m.def("vpt::set_vpt_mode_from_name", setVPTModeFromName);
     m.def("vpt::set_denoiser", setDenoiser);
+    m.def("vpt::set_denoiser_property", setDenoiserProperty);
     m.def("vpt::set_pytorch_denoiser_model_file", setPyTorchDenoiserModelFile);
     m.def("vpt::set_output_foreground_map", setOutputForegroundMap);
     m.def("vpt::set_use_transfer_function", setUseTransferFunction);
@@ -776,6 +777,10 @@ void setDenoiser(const std::string& denoiserName) {
     if (mode == IM_ARRAYSIZE(DENOISER_NAMES)) {
         sgl::Logfile::get()->writeError("Error in setDenoiser: Invalid denoiser name \"" + denoiserName + "\".");
     }
+}
+
+void setDenoiserProperty(const std::string& key, const std::string& value) {
+    vptRenderer->setDenoiserProperty(key, value);
 }
 
 void setPyTorchDenoiserModelFile(const std::string& denoiserModelFilePath) {

--- a/src/PyTorch/Module.hpp
+++ b/src/PyTorch/Module.hpp
@@ -71,6 +71,7 @@ MODULE_OP_API void setCameraFOVy(double FOVy);
 MODULE_OP_API void setVPTMode(int64_t mode);
 MODULE_OP_API void setVPTModeFromName(const std::string& modeName);
 MODULE_OP_API void setDenoiser(const std::string& denoiserName);
+MODULE_OP_API void setDenoiserProperty(const std::string& key, const std::string& value);
 MODULE_OP_API void setPyTorchDenoiserModelFile(const std::string& denoiserModelFilePath);
 MODULE_OP_API void setOutputForegroundMap(bool _shallOutputForegroundMap);
 MODULE_OP_API void setFeatureMapType(int64_t type);

--- a/src/PyTorch/Module.hpp
+++ b/src/PyTorch/Module.hpp
@@ -44,6 +44,7 @@ MODULE_OP_API void setEnvironmentMapIntensityFactor(double intensityFactor);
 MODULE_OP_API void setEnvironmentMapIntensityFactorRgb(std::vector<double> intensityFactor);
 
 MODULE_OP_API void disableEnvMapRot();
+MODULE_OP_API void setEnvMapRotCamera();
 MODULE_OP_API void setEnvMapRotEulerAngles(std::vector<double> eulerAnglesVec);
 MODULE_OP_API void setEnvMapRotYawPitchRoll(std::vector<double> yawPitchRollVec);
 MODULE_OP_API void setEnvMapRotAngleAxis(std::vector<double> _axisVec, double _angle);

--- a/src/PyTorch/Module.hpp
+++ b/src/PyTorch/Module.hpp
@@ -90,6 +90,10 @@ MODULE_OP_API void setSurfaceBrdf(const std::string& _surfaceBrdf);
 MODULE_OP_API void setUseIsosurfaceTf(bool _useIsosurfaceTf);
 MODULE_OP_API void setNumIsosurfaceSubdivisions(int64_t _subdivs);
 
+MODULE_OP_API void setUseClipPlane(bool _useClipPlane);
+MODULE_OP_API void setClipPlaneNormal(std::vector<double> _clipPlaneNormal);
+MODULE_OP_API void setClipPlaneDistance(double _clipPlaneDistance);
+
 MODULE_OP_API void setSeedOffset(int64_t offset);
 
 MODULE_OP_API void setViewProjectionMatrixAsPrevious();

--- a/src/PyTorch/VolumetricPathTracingModuleRenderer.cpp
+++ b/src/PyTorch/VolumetricPathTracingModuleRenderer.cpp
@@ -250,13 +250,22 @@ void VolumetricPathTracingModuleRenderer::setFeatureMapType(FeatureMapTypeVpt ty
 void VolumetricPathTracingModuleRenderer::setDenoiserType(DenoiserType _denoiserType) {
     if (denoiserType != _denoiserType) {
         denoiserType = _denoiserType;
+        denoiserSettings.clear();
         isDenoiserDirty = true;
     }
+}
+
+void VolumetricPathTracingModuleRenderer::setDenoiserProperty(const std::string& key, const std::string& value) {
+    denoiserSettings.insert(std::make_pair(key, value));
+    isDenoiserDirty = true;
 }
 
 void VolumetricPathTracingModuleRenderer::checkDenoiser() {
     if (isDenoiserDirty) {
         vptPass->setDenoiserType(denoiserType);
+        if (!denoiserSettings.empty()) {
+            vptPass->setDenoiserSettings(denoiserSettings);
+        }
         isDenoiserDirty = false;
     }
 }

--- a/src/PyTorch/VolumetricPathTracingModuleRenderer.hpp
+++ b/src/PyTorch/VolumetricPathTracingModuleRenderer.hpp
@@ -96,6 +96,7 @@ public:
     void setUseFeatureMaps(const std::unordered_set<FeatureMapTypeVpt>& featureMapSet);
     void setFeatureMapType(FeatureMapTypeVpt type);
     void setDenoiserType(DenoiserType _denoiserType);
+    void setDenoiserProperty(const std::string& key, const std::string& value);
     void checkDenoiser();
 
     void setEmissionCap(double emissionCap);
@@ -181,6 +182,7 @@ private:
     std::shared_ptr<ConvertTransmittanceVolumePass> convertTransmittanceVolumePass;
 
     DenoiserType denoiserType = DenoiserType::NONE;
+    std::unordered_map<std::string, std::string> denoiserSettings;
     bool isDenoiserDirty = false;
 
     sgl::vk::ImageViewPtr renderImageView;

--- a/src/Utils/NormalizeNormalsPass.cpp
+++ b/src/Utils/NormalizeNormalsPass.cpp
@@ -1,0 +1,70 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2024, Christoph Neuhauser
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Math/Math.hpp>
+#include <Graphics/Vulkan/Render/Renderer.hpp>
+
+#include "NormalizeNormalsPass.hpp"
+
+void NormalizeNormalsPass::setImages(
+        const sgl::vk::ImageViewPtr& _inputImage, const sgl::vk::ImageViewPtr& _outputImage) {
+    if (inputImage != _inputImage) {
+        inputImage = _inputImage;
+        if (computeData) {
+            computeData->setStaticImageView(inputImage, "inputImage");
+        }
+    }
+    if (outputImage != _outputImage) {
+        outputImage = _outputImage;
+        if (computeData) {
+            computeData->setStaticImageView(outputImage, "outputImage");
+        }
+    }
+}
+
+void NormalizeNormalsPass::loadShader() {
+    sgl::vk::ShaderManager->invalidateShaderCache();
+    std::map<std::string, std::string> preprocessorDefines;
+    preprocessorDefines.insert(std::make_pair("BLOCK_SIZE", std::to_string(BLOCK_SIZE)));
+    shaderStages = sgl::vk::ShaderManager->getShaderStages({ "NormalizeNormals.Compute" }, preprocessorDefines);
+}
+
+void NormalizeNormalsPass::createComputeData(sgl::vk::Renderer* renderer, sgl::vk::ComputePipelinePtr& computePipeline) {
+    computeData = std::make_shared<sgl::vk::ComputeData>(renderer, computePipeline);
+    computeData->setStaticImageView(inputImage, "inputImage");
+    computeData->setStaticImageView(outputImage, "outputImage");
+}
+
+void NormalizeNormalsPass::_render() {
+    auto& imageSettings = inputImage->getImage()->getImageSettings();
+    renderer->dispatch(
+            computeData,
+            sgl::uiceil(imageSettings.width, BLOCK_SIZE),
+            sgl::uiceil(imageSettings.height, BLOCK_SIZE),
+            1);
+}

--- a/src/Utils/NormalizeNormalsPass.hpp
+++ b/src/Utils/NormalizeNormalsPass.hpp
@@ -1,0 +1,50 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2024, Christoph Neuhauser
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLOUDRENDERING_NORMALIZENORMALSPASS_HPP
+#define CLOUDRENDERING_NORMALIZENORMALSPASS_HPP
+
+#include <Graphics/Vulkan/Render/Passes/Pass.hpp>
+
+class NormalizeNormalsPass : public sgl::vk::ComputePass {
+public:
+    explicit NormalizeNormalsPass(sgl::vk::Renderer* renderer) : ComputePass(renderer) {}
+    ~NormalizeNormalsPass() override = default;
+    void setImages(const sgl::vk::ImageViewPtr& _inputImage, const sgl::vk::ImageViewPtr& _outputImage);
+
+protected:
+    void loadShader() override;
+    void createComputeData(sgl::vk::Renderer* renderer, sgl::vk::ComputePipelinePtr& computePipeline) override;
+    void _render() override;
+    const uint32_t BLOCK_SIZE = 16;
+
+private:
+    sgl::vk::ImageViewPtr inputImage, outputImage;
+};
+
+#endif //CLOUDRENDERING_NORMALIZENORMALSPASS_HPP


### PR DESCRIPTION
This PR mainly fixes wrong importance sampling cancellations introduced when first implementing the Disney and the Cook Torrance BRDF. This fix improves the behaviour of both BRDFs, especially when a hit is specular.